### PR TITLE
Added Gemfile, making sequenseserver work with bundler.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "http://rubygems.org"
+# Add dependencies required to use your gem here.
+# Example:
+#   gem "activesupport", ">= 2.3.5"
+gem 'ptools', '>=1.2.1'
+gem 'sinatra', '>=1.2.6'
+


### PR DESCRIPTION
Hi there,

This is just a pretty trivial commit to make sequenceserver bundler-compatible. There are 2 reasons for this:
1.  Even though the readme sez "The following ruby gems will self-install: sinatra", this does not occur as far as I can tell. Perhaps I am misunderstanding the meaning of that sentence?
2.  When using database_formatter.rb, the ptools gem is required.
3.  Other gems might also be required in the future, such as bio-graphics or bioruby, and bundler will future-proof the install instructions.

If this pull request is accepted, I would also suggest changing the install instructions, replacing

```
gem install sinatra
```

with

```
gem install bundler && bundle install
```

Agree?
Thanks,
ben
