### PR TITLE
raise ArgumentError if no DB is selected instead of harder to understand whiny nil

### DIFF
--- a/sequenceserver.rb
+++ b/sequenceserver.rb
@@ -164,9 +164,15 @@ module SequenceServer
     end
 
     post '/' do
-      method     = params['method']
-      db_type    = params['db'].first.first
-      sequence   = params[:sequence]
+      method        = params['method']
+      db_type_param = params['db']
+      sequence      = params[:sequence]
+      
+      # Raise ArgumentError if there is no database selected
+      if db_type_param.nil?
+        raise ArgumentError, "No BLAST database selected"
+      end
+      db_type = db_type_param.first.first
 
       # evaluate empty sequence as nil, otherwise as fasta
       sequence = sequence.empty? ? nil : to_fasta(sequence)


### PR DESCRIPTION
If no db was selected before, there was a "no such method 'first' for nil". This commit changes that to a regular argument error. Will this be prevented by the javascript now (I comment it out for now) or in future?

Thanks,
ben
