### PR TITLE
gracefully deal with short BLAST query strings that are not classified as

### DIFF
--- a/lib/sequencehelpers.rb
+++ b/lib/sequencehelpers.rb
@@ -58,6 +58,7 @@ module SequenceServer
     # Return the database type that can be used for a given blast method.
     #   db_type_for("blastp")  => :protein
     #   db_type_for("tblastn") => :nucleotide
+    #   db_type_for(nil)       => nil
     def db_type_for(blast_method)
       case blast_method
       when 'blastp', 'blastx'
@@ -70,12 +71,15 @@ module SequenceServer
     # Return the blast methods that can be used for a given type of sequence.
     #   blast_methods_for(:protein)     => ['blastp', 'tblastn']
     #   blast_methods_for(:nucleotide)  => ['blastn','tblastx','blastx']
+    #   blast_methods_for(nil)          => ['blastp', 'tblastn','blastn','tblastx','blastx']
     def blast_methods_for(seq_type)
       case seq_type
       when :protein
         ['blastp', 'tblastn']
       when :nucleotide
         ['blastn','tblastx','blastx']
+      else # Sequence type not predicted, so don't make any assumptions about the blast method
+        ['blastp', 'tblastn','blastn','tblastx','blastx']
       end
     end
 

--- a/tests/test_sequencehelpers.rb
+++ b/tests/test_sequencehelpers.rb
@@ -47,6 +47,12 @@ class Tester < Test::Unit::TestCase
     assert_raise(ArgumentError, 'mixed aa and nt should raise') { type_of_sequences(aa_nt_mix) }
   end
 
+  def test_sequence_type_to_blast_methods
+    assert_equal ['blastp', 'tblastn'], blast_methods_for(:protein), 'blasts_for_protein'
+    assert_equal ['blastn','tblastx','blastx'], blast_methods_for(:nucleotide), 'blasts_for_nucleotide'
+    assert_equal ['blastp', 'tblastn','blastn','tblastx','blastx'], blast_methods_for(nil), 'blasts_for_nil'
+  end
+
   def test_composition
     expected_comp = {"a"=>2, "d"=>3, "f"=>7, "s"=>3, "A"=>1}
     assert_equal(expected_comp, composition('asdfasdfffffAsdf'))


### PR DESCRIPTION
gracefully deal with short BLAST query strings that are not classified as either protein or nucleotide, instead of throwing a whiny nil error. closes #36
