### PR TITLE
add newline to inserted custom hyperlink in results

### DIFF
--- a/sequenceserver.rb
+++ b/sequenceserver.rb
@@ -372,7 +372,7 @@ module SequenceServer
         return line
       else
         settings.log.debug('Added link for: `'+ sequence_id +'\''+ link)
-        return "><a href='#{link}'>#{sequence_id}</a> "
+        return "><a href='#{link}'>#{sequence_id}</a> \n"
       end
 
     end


### PR DESCRIPTION
on my outputs before I was seeing

```
><a href='/get_sequence/:AAKM01000034/:/home/ben/forays/sequenceserver/db/PvivaxGenomic_PlasmoDB-7.0.fasta'>gb|AAKM01000034| | organism=Plasmodium_vivax_SaI-1 | version=2007-06-13 | length=16697</a> Length=16697    
```

with this simple fix

```
><a href='/get_sequence/:AAKM01000034/:/home/ben/forays/sequenceserver/db/PvivaxGenomic_PlasmoDB-7.0.fasta'>gb|AAKM01000034| | organism=Plasmodium_vivax_SaI-1 | version=2007-06-13 | length=16697</a> 
Length=16697
```

The Length=16697 is from the next blast line after the id line starting with >
