### PR TITLE
webpage: Added output filename with .zip extension download instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
 		Extensive details in the <a href="https://github.com/yannickwurm/sequenceserver/blob/master/README.mkd">README</a> file. In short: 
 		<ul>
 		  <li>Download sequenceserver. Either with <a href="http://github.com/yannickwurm/sequenceserver/zipball/master">this link</a> or copy-paste the following into the command-line:
-			<pre>$ wget http://github.com/yannickwurm/sequenceserver/zipball/master</pre>
+			<pre>$ wget http://github.com/yannickwurm/sequenceserver/zipball/master -O sequenceserver.zip</pre>
 		  </li>
 		  <li>Unzip, and move to Sequence Server's directory, and do: 
 			<pre>$ gem install bundler &amp;&amp; bundle install</pre>


### PR DESCRIPTION
So that the downloaded file can be opened by double-cleck, right-click etc.

Otherwise you just get a file 'master' which isn't very nice to deal with.
