### PR TITLE
config: make the example BLAST+ directory 2.2.25+, to be in line with rec

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -6,7 +6,7 @@
 #
 # Uncomment the following line, and change to appropriate value to use.
 #
-# bin: ~/ncbi-blast-2.2.24+/bin/
+# bin: ~/ncbi-blast-2.2.25+/bin/
 
 # Path to blast database.
 #


### PR DESCRIPTION
config: make the example BLAST+ directory 2.2.25+, not 2.2.24+, to be in line with recommended BLAST+ version.
