### PR TITLE
make the blastdbcmd sequence extractor respect the path in config

### DIFF
--- a/lib/sequencehelpers.rb
+++ b/lib/sequencehelpers.rb
@@ -83,12 +83,12 @@ module SequenceServer
       end
     end
 
-    def sequence_from_blastdb(identifiers, db)  # helpful when displaying parsed blast results
+    def sequence_from_blastdb(identifiers, db, blastdbcmd)  # helpful when displaying parsed blast results
       entries_to_get = identifiers           if identifiers.class == String
       entries_to_get = identifiers.join(',') if identifiers.class == Array
       raise ArgumentError, "No ids to fetch: #{identifiers.to_s}" if entries_to_get.empty?
 
-      sequences = %x|blastdbcmd -db #{db} -entry #{entries_to_get} 2>&1|
+      sequences = %x|#{blastdbcmd} -db #{db} -entry #{entries_to_get} 2>&1|
       if sequences.include?("No valid entries to search") 
         raise ArgumentError, "Cannot find ids: #{entries_to_get} in #{db}." +
         "OR makeblastdb needs to be rerun with '-parse_seqids'"

--- a/sequenceserver.rb
+++ b/sequenceserver.rb
@@ -283,7 +283,7 @@ module SequenceServer
 
       retrieval_databases.each do |database|     # we need to populate this session variable from the erb.
         begin
-          found_sequences += sequence_from_blastdb(sequenceids, database)
+          found_sequences += sequence_from_blastdb(sequenceids, database, settings.binaries['blastdbcmd'])
         rescue
           settings.log.debug('None of the following sequences: '+ sequenceids.to_s + ' found in '+ database)
         end


### PR DESCRIPTION
Signed-off-by: Ben J Woodcroft <gmail.com after donttrustben>

As you can see from the diff, the config wasn't being respected when extracting sequences.

Relatedly, it would be good to log exactly what is being run here - should we use 

```
settings.log.debug
```

within the SequenceHelpers module? Currently, I don't think any logging is done from outside sequenceserver.rb, but might be wrong on this.
