### PR TITLE
Don't clear the choice of blast method when the query sequence is deleted or changed, if appropriate

### DIFF
--- a/public/js/sequenceserver.js
+++ b/public/js/sequenceserver.js
@@ -118,16 +118,28 @@ $(document).ready(function(){
 
     $('#sequence').bind('sequence_type_changed', function(event, type){
         if (type == "nucleotide"){
+            // enable blast methods suitable for a nucleotide query
             $("#blastn, #tblastx, #blastx").enable();
-            $("#blastp, #tblastn").uncheck().disable().first().change();
+            // uncheck the method if an unsuitable method was chosen
+            if ($("#blastp").prop('checked') || $("#tblastn").prop('checked')){
+                $("#blastp, #tblastn").uncheck();
+            }
+            // disable unsuitable methods
+            $("#blastp, #tblastn").disable();
         }
         else if (type == "protein"){
+            // enable blast methods suitable for a protein query
             $("#blastp, #tblastn").enable();
-            $("#blastn, #tblastx, #blastx").uncheck().disable().first().change();
+            // uncheck the method if an unsuitable method was chosen
+            if ($("#blastn").prop('checked') || $("#tblastx").prop('checked') || $("#blastx").prop('checked')){
+                $("#blastp, #tblastn").uncheck();
+            }
+            // disable unsuitable methods
+            $("#blastn, #tblastx, #blastx").disable();
         }
         else if (type == undefined){
-            //reset blast methods
-            $('.blastmethods input[type=radio]').enable().first().change();
+            //make all blast method choices available. Leave the current choice in place
+            $('.blastmethods input[type=radio]').enable();
         }
     });
 


### PR DESCRIPTION
e.g. if the user inputs a nucleotide sequence,
 chooses blastn,
 then does a blast,
 then deletes the whole sequence and puts in another nucleotide sequence,

the choice of 'blastn' should be left in place as it is likely
to be the method used. Currently all choices become available again.

At least from personal experience..

Signed-off-by: Ben J Woodcroft <gmail.com after donttrustben>

This is scratching my own itch, I guess, as I often seem to run a certain type of query consecutively. I realised actually that it is a bit of a temporary fix though - once we eliminate the blast methods section (#72) this will become redundant. Hence if you don't want to be bothered merging I totally understand.
