### PR TITLE
Determine which database hit came from and pass this database to customization functions.

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -472,11 +472,16 @@ HEADER
 
       link = nil
 
+      # Identify which database hit came from
+      original_seq_id = sequence_id[/\|[^\s]+/][1..-1]
+      hit_database = databases.select{|db| !sequence_from_blastdb(original_seq_id, db).empty?}
+
       # If a custom sequence hyperlink method has been defined,
       # use that.
       options = {
         :sequence_id => sequence_id,
         :databases => databases,
+        :hit_database => hit_database,
         :hit_coordinates => hit_coordinates
       }
 


### PR DESCRIPTION
The purpose of this feature is to resolve the problem mentioned here:
https://groups.google.com/forum/#!topic/sequenceserver/nY0bU-lKm-Y
