### PR TITLE
Added a crude way to eliminate name collisions

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -368,7 +368,8 @@ HEADER
       sequence.lstrip!
       unique_queries = Hash.new()
       if sequence[0,1] != '>'
-        ip   = request.ip.to_s
+        # To make sure request.ip returns some useful information
+        ip   = request.ip.to_s rescue '0.0.0.0'
         time = Time.now.strftime("%y%m%d-%H:%M:%S")
         sequence.insert(0, ">Submitted_By_#{ip}_at_#{time}\n")
       end

--- a/spec/sequencehelpers_spec.rb
+++ b/spec/sequencehelpers_spec.rb
@@ -48,22 +48,6 @@ describe 'Sequence helpers' do
     expect { type_of_sequences(aa_nt_mix) }.to raise_error(ArgumentError)
   end
 
-  it 'test_to_fasta' do
-    query_no_header = 'TACTGCTAGTCGATCGTCGATGCTAGCTGAC'
-    query_with_header = '>athcatrandom\nTACTGCTAGTCGATCGTCGATGCTAGCTGAC'
-    assert_equal(">", to_fasta(query_no_header)[0,1])
-    assert_equal(query_with_header, to_fasta(query_with_header))
-  end
-
-  it 'test_unique_sequence_ids' do
-    aa_multifasta = ">a\nATGCTCA\n>bob\nGTCGCGA\n>a\nATGCTCAAGAa\n>c\nGTacgtcgCGCGA>bob\nrandom\ncomments\nTAGGCGACT"
-    aa_multifasta_out = ">a\nATGCTCA\n>bob\nGTCGCGA\n>a_1\nATGCTCAAGAa\n>c\nGTacgtcgCGCGA>bob_1\nrandom\ncomments\nTAGGCGACT"
-    aa_multifasta_with_missing_lead = "ACGTGSDLKJGNLDK\n>a\natgctgatcgta\n>b\natgctgatcgta"
-    aa_multifasta_with_missing_lead_out = ">fasta\n"+"ACGTGSDLKJGNLDK\n>a\natgctgatcgta\n>b\natgctgatcgta"
-    assert_equal(aa_multifasta_out, to_fasta(aa_multifasta))
-    assert_equal('>', to_fasta(aa_multifasta_with_missing_lead_out)[0,1])
-  end
-
   it 'test_composition' do
     expected_comp = {"a"=>2, "d"=>3, "f"=>7, "s"=>3, "A"=>1}
     assert_equal(expected_comp, composition('asdfasdfffffAsdf'))
@@ -76,6 +60,25 @@ describe 'Sequence helpers' do
   end
 end
 
+describe 'sequence id checker' do
+  app = SequenceServer::App.new!
+  it 'test_to_fasta' do
+    query_no_header = 'TACTGCTAGTCGATCGTCGATGCTAGCTGAC'
+    query_with_header = '>athcatrandom\nTACTGCTAGTCGATCGTCGATGCTAGCTGAC'
+    assert_equal(">", app.to_fasta(query_no_header)[0,1])
+    assert_equal(query_with_header, app.to_fasta(query_with_header))
+  end
+
+  it 'test_unique_sequence_ids' do
+    aa_multifasta = ">a\nATGCTCA\n>bob\nGTCGCGA\n>a\nATGCTCAAGAa\n>c\nGTacgtcgCGCGA\n>bob\nrandom\ncomments\nTAGGCGACT"
+    aa_multifasta_out = ">a\nATGCTCA\n>bob\nGTCGCGA\n>a_1\nATGCTCAAGAa\n>c\nGTacgtcgCGCGA\n>bob_1\nrandom\ncomments\nTAGGCGACT"
+    aa_multifasta_with_missing_lead = "ACGTGSDLKJGNLDK\n>a\natgctgatcgta\n>b\natgctgatcgta"
+    aa_multifasta_with_missing_lead_out = ">fasta\n"+"ACGTGSDLKJGNLDK\n>a\natgctgatcgta\n>b\natgctgatcgta"
+    assert_equal(aa_multifasta_out, app.to_fasta(aa_multifasta))
+    assert_equal('>', app.to_fasta(aa_multifasta_with_missing_lead_out)[0,1])
+  end
+end
+    
 describe 'app tester' do
   it 'test_process_advanced_blast_options' do
     app = SequenceServer::App.new!


### PR DESCRIPTION
Hi,

> It took some time to understand the codebase and the process in still underway. This change is _little_ crude but seems to work for the time being in reference to issue #109. Please suggest any improvements you see.

As proposed, I have moved this method to to_fasta function for being more generic and faster. This works but not the way I wanted it cause the Hash object has effectively no role in here. I don't know what was the problem but when I tried to -

```
     sequence.gsub!(/^>(.+)/) do |s|
       unique_queries.has_key?(s) ? unique_queries[s] += 1 : unique_queries[s] = 1
       s + '_' + unique_queries[s].to_s
     end
```

to grab all the sequence ids, and accordingly update them, the original sequence was getting modified in a weird way.

Input Sequence:

```
    > a
    ATGCTCA
    > b
    GTCGCGA
```

Output Sequence:

```
    _ a
    ATGCTCA
    _ b 
    GTCGCGA
```

Which obviously throws an error. Is this a regex problem or the code written is wrong?

@yannickwurm 
