### PR TITLE
Added Hotkey Ctrl+Enter for quick blasting

### DIFF
--- a/public/js/sequenceserver.js
+++ b/public/js/sequenceserver.js
@@ -122,6 +122,13 @@ $(document).ready(function(){
 
     var notification_timeout;
 
+    // Handles the form submission when Ctrl+Enter is pressed anywhere on page
+    $(document).bind("keydown", function (e) {
+        if (e.ctrlKey && e.keyCode === 13 && !$('#method').is(':disabled')) {
+            $('#method').trigger('submit');
+        }
+    });
+
     $('#sequence').on('sequence_type_changed', function (event, type) {
         clearTimeout(notification_timeout);
         $(this).parent('.control-group').removeClass('error');


### PR DESCRIPTION
This patch fixes the issue #90, thus allowing users to quick blast using the shortcut Ctrl+Enter while anywhere on the page. It is made sure that a sequence value is filled up and appropriate database is
selected.

@yannickwurm
