### PR TITLE
add a physical close button ('x') to the sequence-viewer modal

### DIFF
--- a/views/search.erb
+++ b/views/search.erb
@@ -406,6 +406,7 @@
         class="modal-content">
         <div
           class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
           <h3>View and download sequence</h3>
         </div>
 


### PR DESCRIPTION
This is not a necessary feature, but I think that it's a good idea to have a physical button that dismisses the modal for optimal user experience 

Users can still click outside the modal or press <kbd>esc</kbd> to dismiss the modal, but I don't think this would be glaringly obvious to everyone...

Thoughts...

Signed-off-by: IsmailM ismail.moghul@gmail.com
