### PR TITLE
Fixing double e value

### DIFF
--- a/lib/sequenceserver/blast/job.rb
+++ b/lib/sequenceserver/blast/job.rb
@@ -91,20 +91,21 @@ module SequenceServer
       private
 
       def parse_advanced param_line
-        param_list = param_line.split(" ")
+        param_list = param_line.split(' ')
         res = {}
 
         param_list.each_with_index do |word, i|
           nxt = param_list[i + 1]
-          if word.start_with? "-"
-            word.sub!("-", "")
-            unless nxt.nil? || nxt.start_with?("-")
+          if word.start_with? '-'
+            word.sub!('-', '')
+            unless nxt.nil? || nxt.start_with?('-')
               res[word] = nxt
             else
-              res[word] = "True"
+              res[word] = 'True'
             end
           end
         end
+        res.delete 'evalue'
         res
       end
 

--- a/lib/sequenceserver/blast/report.rb
+++ b/lib/sequenceserver/blast/report.rb
@@ -85,9 +85,10 @@ module SequenceServer
       # matrix, evalue, gapopen, gapextend, and filters are available from XML
       # output.
       def extract_params(ir)
-        @params = Hash[
+        params = Hash[
           *ir[7].first.map { |k, v| [k.gsub('Parameters_', ''), v] }.flatten
         ].merge(job.advanced_params)
+        @params = Hash['e value', params.delete('expect')].merge!(params)
       end
 
       # Make search stats available via `stats` attribute.


### PR DESCRIPTION
Signed-off-by: Filip Ter <filip.ter@gmail.com>

This addresses the problem that when evalue is specified it’s once shown as expect and once as e value. This fix is to forget the user-supplied e value, since it is already part of the blast xml output, and rename the expect key to e value. 