### PR TITLE
Automatically remove jobdirs

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -9,6 +9,7 @@ require 'sequenceserver/sequence'
 require 'sequenceserver/database'
 require 'sequenceserver/blast'
 require 'sequenceserver/routes'
+require 'sequenceserver/job_remover'
 
 # Top level module / namespace.
 module SequenceServer
@@ -38,11 +39,14 @@ module SequenceServer
 
     def init(config = {})
       @config = Config.new(config)
+      Thread.abort_on_exception = true if ENV['RACK_ENV'] == 'development'
 
       init_binaries
       init_database
       load_extension
       check_num_threads
+      @job_remover = JobRemover.new(@config[:job_lifetime])
+
       self
 
       # We don't validate port and host settings. If SequenceServer is run

--- a/lib/sequenceserver/job.rb
+++ b/lib/sequenceserver/job.rb
@@ -12,6 +12,7 @@ module SequenceServer
   # Sub-classes must at least define `run` instance method.
   class Job
     DOTDIR = File.expand_path('~/.sequenceserver')
+    UUID_PATTERN = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/
 
     class << self
       # Creates and queues a job. Returns created job object.
@@ -26,6 +27,15 @@ module SequenceServer
       # TODO: What if the given job id does not exist?
       def fetch(id)
         YAML.load_file(File.join(DOTDIR, id, 'job.yaml'))
+      end
+
+      def all
+        jobdirs = Dir["#{DOTDIR}/*"].select{ |f| f =~ UUID_PATTERN }
+        jobdirs.map{ |fname| fetch File.basename(fname) }
+      end
+
+      def delete(id)
+        FileUtils.rm_r File.join(DOTDIR, id)
       end
 
       private
@@ -57,7 +67,7 @@ module SequenceServer
       raise e
     end
 
-    attr_reader :id
+    attr_reader :id, :completed_at
 
     # How to execute the job.
     #
@@ -101,6 +111,7 @@ module SequenceServer
 
     # Marks the job as done.
     def done!
+      @completed_at = Time.now
       @done = true
       save
     end

--- a/lib/sequenceserver/job_remover.rb
+++ b/lib/sequenceserver/job_remover.rb
@@ -1,0 +1,65 @@
+require 'sequenceserver/job.rb'
+
+module SequenceServer 
+  class JobRemover
+
+    DEFAULT_LIFETIME = 86400
+
+    def initialize(lifetime)
+      parse lifetime
+      spawn_cleanup if @clean_needed
+    end
+
+    extend Forwardable
+    def_delegators SequenceServer, :logger
+
+    def spawn_cleanup
+
+      Thread.new do 
+        loop do
+          begin
+            #leave incomplete jobs
+            finished_jobs = Job.all.select{ |f| f.done? }
+            now = Time.now
+
+            unless finished_jobs.empty?
+              exp_jobs = finished_jobs.select do |job|
+                (job.completed_at + @lifetime) < now
+              end
+
+              exp_jobs.each{ |job| Job.delete job.id }
+            end
+
+            remaining_jobs = (exp_jobs.nil?) ? finished_jobs : finished_jobs - exp_jobs
+            oldest_time = remaining_jobs.map(&:completed_at).min
+
+            @next_cleanup = @lifetime
+            if  !!oldest_time && now < (oldest_time + @lifetime)
+              @next_cleanup = (oldest_time + @lifetime) - now
+            end
+
+            sleep(@next_cleanup.to_i)
+          rescue => e #StandardError
+            logger.debug("Cleanup thread shutting down due to Error:")
+            logger.debug(e.inspect)
+            logger.debug(e.backtrace.join("\n"))
+
+            Thread.exit
+          end
+        end
+      end
+    end
+
+    def parse(job_lifetime)
+      @clean_needed = true
+      if job_lifetime.nil?
+        @lifetime = DEFAULT_LIFETIME
+      elsif job_lifetime == "INF"
+        @clean_needed = false
+      else
+        @lifetime = job_lifetime.to_i * 60
+      end
+    end
+
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -78,10 +78,11 @@ module SequenceServer
     end
 
     it 'merges arguments with defaults and values from config_file,' \
-       'arguments taking preecedence' do
+       'arguments taking precedence' do
       config = Config.new(:config_file => sample_config_file,
-                          :num_threads => 20)
+                          :num_threads => 20, :job_lifetime => "INF")
       config[:num_threads].should eq 20
+      config[:job_lifetime].should eq "INF"
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Filip Ter <filip.ter@gmail.com>

Periodically removes job directories in dotdir. The user should be able to define the lifetime of each job dir. The default is 24 hours. The time can be specified in the config file using the format
“minutes-hours-days”(i.e. "08-10-12"). If the string “INF” is given, no files will ever be deleted. If only one number is specified, hours will be assumed. 