### PR TITLE
split on newline because some filenames contain spaces

### DIFF
--- a/sequenceserver.gemspec
+++ b/sequenceserver.gemspec
@@ -31,7 +31,7 @@ DESC
                                '~> 0.4', '>= 0.4.7')
 
   # gem
-  s.files         = `git ls-files`.split
+  s.files         = `git ls-files`.split("\n")
   s.executables   = ['sequenceserver']
   s.require_paths = ['lib']
 


### PR DESCRIPTION
Error:

```
$ gem build sequenceserver.gemspec                                                                                                          sequenceserver
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["FLV", "Player.hxproj", "public/vendor/npm/webshim@1.15.8/swfs/jaris/Jaris"] are not files
```