### PR TITLE
Added support for tmp files to be saved

### DIFF
--- a/lib/sequenceserver/blast/formatter.rb
+++ b/lib/sequenceserver/blast/formatter.rb
@@ -24,7 +24,8 @@ module SequenceServer
       attr_reader :format, :mime, :specifiers
 
       def file
-        @file ||= Tempfile.new filename
+        # @file ||= Tempfile.new filename
+        @file = File.join(File.dirname(archive_file), filename)
       end
 
       def filename
@@ -38,11 +39,15 @@ module SequenceServer
         command =
           "blast_formatter -archive '#{archive_file}'" \
           " -outfmt '#{format} #{specifiers}'" \
-          " -out '#{file.path}' 2> /dev/null"
-        logger.debug("Executing: #{command}")
-        Dir.chdir(File.exist?(DOTDIR) && DOTDIR || Dir.pwd) do
-          system(command)
-        end
+          " -out '#{file}' 2> /dev/null"
+          if File.exist?(file)
+            logger.debug("File exist: #{file}")
+          else
+            logger.debug("Executing: #{command}")
+            Dir.chdir(File.exist?(DOTDIR) && DOTDIR || Dir.pwd) do
+              system(command)
+            end
+          end
       end
 
       def validate

--- a/lib/sequenceserver/blast/formatter.rb
+++ b/lib/sequenceserver/blast/formatter.rb
@@ -24,7 +24,6 @@ module SequenceServer
       attr_reader :format, :mime, :specifiers
 
       def file
-        # @file ||= Tempfile.new filename
         @file = File.join(File.dirname(archive_file), filename)
       end
 
@@ -36,13 +35,13 @@ module SequenceServer
       private
 
       def run
-        command =
-          "blast_formatter -archive '#{archive_file}'" \
-          " -outfmt '#{format} #{specifiers}'" \
-          " -out '#{file}' 2> /dev/null"
           if File.exist?(file)
             logger.debug("File exist: #{file}")
           else
+            command =
+              "blast_formatter -archive '#{archive_file}'" \
+              " -outfmt '#{format} #{specifiers}'" \
+              " -out '#{file}' 2> /dev/null"
             logger.debug("Executing: #{command}")
             Dir.chdir(File.exist?(DOTDIR) && DOTDIR || Dir.pwd) do
               system(command)

--- a/lib/sequenceserver/blast/formatter.rb
+++ b/lib/sequenceserver/blast/formatter.rb
@@ -35,18 +35,15 @@ module SequenceServer
       private
 
       def run
-          if File.exist?(file)
-            logger.debug("File exist: #{file}")
-          else
-            command =
-              "blast_formatter -archive '#{archive_file}'" \
-              " -outfmt '#{format} #{specifiers}'" \
-              " -out '#{file}' 2> /dev/null"
-            logger.debug("Executing: #{command}")
-            Dir.chdir(File.exist?(DOTDIR) && DOTDIR || Dir.pwd) do
-              system(command)
-            end
-          end
+        return if File.exist?(file)
+        command =
+          "blast_formatter -archive '#{archive_file}'" \
+          " -outfmt '#{format} #{specifiers}'" \
+          " -out '#{file}' 2> /dev/null"
+        logger.debug("Executing: #{command}")
+        Dir.chdir(File.exist?(DOTDIR) && DOTDIR || Dir.pwd) do
+          system(command)
+        end
       end
 
       def validate

--- a/lib/sequenceserver/blast/report.rb
+++ b/lib/sequenceserver/blast/report.rb
@@ -45,7 +45,6 @@ module SequenceServer
       def generate
         xml = Formatter.run(job.rfile, 'xml').file
         tsv = parse_tsv File.read(Formatter.run(job.rfile, '__ssparse').file)
-        # ir = node_to_array(Ox.parse(xml.open.read).root)
         ir = node_to_array(Ox.parse(File.read(xml)).root)
         extract_program_info ir
         extract_params ir

--- a/lib/sequenceserver/blast/report.rb
+++ b/lib/sequenceserver/blast/report.rb
@@ -44,8 +44,9 @@ module SequenceServer
       # Generate report.
       def generate
         xml = Formatter.run(job.rfile, 'xml').file
-        tsv = parse_tsv Formatter.run(job.rfile, '__ssparse').file
-        ir = node_to_array(Ox.parse(xml.open.read).root)
+        tsv = parse_tsv File.read(Formatter.run(job.rfile, '__ssparse').file)
+        # ir = node_to_array(Ox.parse(xml.open.read).root)
+        ir = node_to_array(Ox.parse(File.read(xml)).root)
         extract_program_info ir
         extract_params ir
         extract_stats ir

--- a/lib/sequenceserver/routes.rb
+++ b/lib/sequenceserver/routes.rb
@@ -120,7 +120,7 @@ module SequenceServer
     get '/download/:jid.:type' do |jid, type|
       job = Job.fetch(jid)
       out = BLAST::Formatter.new(job.rfile, type)
-      send_file out.file.path, :filename => out.filename, :type => out.mime
+      send_file out.file, :filename => out.filename, :type => out.mime
     end
 
     # This error block will only ever be hit if the user gives us a funny


### PR DESCRIPTION
The current manner for downloading the xml or tsv files is to generate them and store them to temporary files and as soon as download of files are over, temporary files gets deleted. Now if user wants to again download them it will again be generated. To save the time consumed in it, why not save the files once generated. Here the files are being saved in the same folder as the archive_file, which is passed along for generating the xml and tsv files.