### PR TITLE
Rename Pool#schedule to Pool#queue

### DIFF
--- a/lib/sequenceserver/job.rb
+++ b/lib/sequenceserver/job.rb
@@ -42,7 +42,7 @@ module SequenceServer
 
       # Queues given job on the thread pool. Returns job.
       def queue(job)
-        SequenceServer.pool.schedule { job.run }
+        SequenceServer.pool.queue { job.run }
         job
       end
     end

--- a/lib/sequenceserver/pool.rb
+++ b/lib/sequenceserver/pool.rb
@@ -38,7 +38,7 @@ class Pool
     end
   end
 
-  def schedule(*args, &block)
+  def queue(*args, &block)
     @jobs << [block, args]
   end
 


### PR DESCRIPTION
The Pool#schedule method was a little misleading. We thought that the job is being scheduled to run at some specific time, but this isn't what happens. What happens is the job is queued to run as soon as server finishes up with previous jobs. So the Pool#queue method instead of Pool#schedule method instead of Pool#schedule make more sense.