### PR TITLE
result URLs not expected to contain hit identifiers

### DIFF
--- a/public/js/report.js
+++ b/public/js/report.js
@@ -1161,7 +1161,7 @@ var Report = React.createClass({
      * Fetch results.
      */
     fetch_results: function () {
-        $.getJSON(location.href + '.json')
+        $.getJSON(location.pathname + '.json')
         .complete(_.bind(function (jqXHR) {
             switch (jqXHR.status) {
             case 202:


### PR DESCRIPTION
If users have previously selected any hits through links in result page summary tables, their browsers history may contain URLs with  fragment identifiers for specific hits. If such links are later selected to reload the result pages we need to make sure that URLs for retrieving the results in json format are still correct.