### PR TITLE
More explicit multipart DB name regex

### DIFF
--- a/lib/sequenceserver/database.rb
+++ b/lib/sequenceserver/database.rb
@@ -222,8 +222,9 @@ module SequenceServer
       # /home/ben/pd.ben/sequenceserver/db/nr.00 => yes
       # /home/ben/pd.ben/sequenceserver/db/nr => no
       # /home/ben/pd.ben/sequenceserver/db/img3.5.finished.faa.01 => yes
+      # /home/ben/pd.ben/sequenceserver/db/nr00 => no
       def multipart_database_name?(db_name)
-        !(db_name.match(%r{.+/\S+\d{2}$}).nil?)
+        !(db_name.match(%r{.+/\S+\.\d{2}$}).nil?)
       end
 
       # Returns true if first character of the file is '>'.

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -84,9 +84,11 @@ module SequenceServer
       sample_name1 = '/home/ben/pd.ben/sequenceserver/db/nr'
       sample_name2 = '/home/ben/pd.ben/sequenceserver/db/nr.00'
       sample_name3 = '/home/ben/pd.ben/sequenceserver/db/img3.5.finished.faa.01'
+      sample_name4 = '/home/ben/pd.ben/sequenceserver/db/nr00'
       Database.multipart_database_name?(sample_name1).should be_falsey
       Database.multipart_database_name?(sample_name2).should be_truthy
       Database.multipart_database_name?(sample_name3).should be_truthy
+      Database.multipart_database_name?(sample_name4).should be_falsey
     end
 
     it 'can tell FASTA files that are yet to be made into a BLAST+ database' do


### PR DESCRIPTION
This is to fix issue #309 regarding DB names with numerical suffixes being incorrectly identified as being multipart. This PR attempts to fix the issue by having a more restrictive regex which requires the multipart numerical suffix to be preceeded by a dot.

I think I also added a test for this case - hope this works!