### PR TITLE
Added forking and 'exec' to the 'sys' method

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -83,34 +83,23 @@ module SequenceServer
     # :stderr => '/path/to/stderr_file')
 
     def sys(command, options = {})
-      # Store the initial value of the PATH environment variable.
-      initial_path = ENV['PATH']
-      # If the value for path to the safe directory is falsey, use the current
-      # value of the PATH environment variable.
-      path = options[:path] || ENV['PATH']
-      # Store the path to the safe directory, if it exists. If it does not
-      # exist, use the initial value of PATH environment variable.
-      safe_path = Dir.exist?(path) && path || ENV['PATH']
-
       # Make temporary files to store output from stdout and stderr.
       temp_stdout_file = Tempfile.new
       temp_stderr_file = Tempfile.new
 
       logger.debug("Executing: #{command}")
 
-      # If the value for the path to the directory is falsey, use the current
-      # working directory.
-      directory = options[:dir] || Dir.pwd
-
       # Fork.
       child_pid = fork do
         # Set the PATH environment variable to the safe directory.
-        ENV['PATH'] = safe_path
-        # Change the directory, execute the shell command, redirect stdout and
-        # stderr to the temporary files.
-        Dir.chdir(Dir.exist?(directory) && directory || Dir.pwd)
-        system("#{command} 1>#{temp_stdout_file.path} 2>#{temp_stderr_file.path}")
-        exit $CHILD_STATUS.exitstatus
+        ENV['PATH'] = options[:path] if options[:path]
+
+        # Change to the specified directory.
+        Dir.chdir(options[:dir]) if options[:dir] and Dir.exist?(options[:dir])
+
+        # Execute the shell command, redirect stdout and stderr to the
+        # temporary files.
+        exec("#{command} 1>#{temp_stdout_file.path} 2>#{temp_stderr_file.path}")
       end
 
       # Wait for the termination of the child process.

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -95,7 +95,7 @@ module SequenceServer
         ENV['PATH'] = options[:path] if options[:path]
 
         # Change to the specified directory.
-        Dir.chdir(options[:dir]) if options[:dir] and Dir.exist?(options[:dir])
+        Dir.chdir(options[:dir]) if options[:dir] && Dir.exist?(options[:dir])
 
         # Execute the shell command, redirect stdout and stderr to the
         # temporary files.
@@ -105,7 +105,7 @@ module SequenceServer
       # Wait for the termination of the child process.
       _, status = Process.wait2(child_pid)
 
-      unless status == 0
+      unless status.zero?
         raise CommandFailed.new(temp_stdout_file.read, temp_stderr_file.read, status)
       end
 

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -105,7 +105,7 @@ module SequenceServer
       # Wait for the termination of the child process.
       _, status = Process.wait2(child_pid)
 
-      unless status.zero?
+      unless status == 0
         raise CommandFailed.new(temp_stdout_file.read, temp_stderr_file.read, status)
       end
 

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -111,7 +111,7 @@ module SequenceServer
         Dir.chdir(Dir.exist?(directory) && directory || Dir.pwd)
         system("#{command} 1>#{temp_stdout_file.path} 2>#{temp_stderr_file.path}")
         exit $CHILD_STATUS.exitstatus
-      end)
+      end
 
       # Wait for the termination of the child process.
       _, status = Process.wait2(child_pid)


### PR DESCRIPTION
The 'sys' method now forks. The child changes PATH, changes directory, and
executes a shell command using 'exec'. 'sys' waits for the child process to end, then checks the exit status of the child process.