### PR TITLE
Have the 'sys' method replace the 'export_bin_dir' method

### DIFF
--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -2,6 +2,7 @@
 require 'readline'
 require 'English'
 require 'slop'
+require 'sequenceserver'
 
 ENV['RACK_ENV'] ||= 'production'
 
@@ -17,7 +18,7 @@ def download_from_url(url)
   cmd = "curl -ip4 -C - #{url} -o #{archive} && " \
         'mkdir -p ~/.sequenceserver && '          \
         "tar xvf #{archive} -C ~/.sequenceserver"
-  system cmd
+  sys(cmd)
 end
 
 begin
@@ -152,8 +153,6 @@ BANNER
         system('stty', stty)
         exit
       end
-
-      require 'sequenceserver'
 
       begin
         SequenceServer.init clean_opts[to_h]

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -273,9 +273,9 @@ module SequenceServer
     def open_in_browser(server_url)
       return if using_ssh? || verbose?
       if RUBY_PLATFORM =~ /linux/ && xdg?
-        system "xdg-open #{server_url}"
+        sys("xdg-open #{server_url}")
       elsif RUBY_PLATFORM =~ /darwin/
-        system "open #{server_url}"
+        sys("open #{server_url}")
       end
     end
 
@@ -289,7 +289,7 @@ module SequenceServer
 
     # Return `true` if the given command exists and is executable.
     def command?(command)
-      system("which #{command} > /dev/null 2>&1")
+      sys("which #{command}")
     end
   end
 end

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -250,14 +250,6 @@ module SequenceServer
       require config[:require]
     end
 
-    # Export NCBI BLAST+ bin dir to PATH environment variable.
-    def export_bin_dir
-      bin_dir = config[:bin]
-      return unless bin_dir
-      return if ENV['PATH'].split(':').include? bin_dir
-      ENV['PATH'] = "#{bin_dir}:#{ENV['PATH']}"
-    end
-
     def assert_blast_installed_and_compatible
       fail BLAST_NOT_INSTALLED unless command? 'blastdbcmd'
       version = `blastdbcmd -version`.split[1]

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -91,7 +91,9 @@ module SequenceServer
 
       # Fork.
       child_pid = fork do
-        # Set the PATH environment variable to the safe directory.
+        # Set the PATH environment variable to the binary directory or
+        # safe directory.
+        ENV['PATH'] = config[:bin] if config[:bin] && !options[:path]
         ENV['PATH'] = options[:path] if options[:path]
 
         # Change to the specified directory.
@@ -189,7 +191,6 @@ module SequenceServer
           fail BIN_DIR_NOT_FOUND, config[:bin]
         end
         logger.debug("Will use NCBI BLAST+ at: #{config[:bin]}")
-        export_bin_dir
       else
         logger.debug('Location of NCBI BLAST+ not provided. Assuming NCBI' \
                      ' BLAST+ to be present in: $PATH')

--- a/lib/sequenceserver/database.rb
+++ b/lib/sequenceserver/database.rb
@@ -168,12 +168,11 @@ module SequenceServer
         _make_blast_database(file, type, title, taxid)
       end
 
-      def _make_blast_database(file, type, title, taxid, quiet = false)
+      def _make_blast_database(file, type, title, taxid)
         cmd = 'makeblastdb -parse_seqids -hash_index ' \
               "-in #{file} -dbtype #{type.to_s.slice(0, 4)} -title '#{title}'" \
               " -taxid #{taxid}"
-        cmd << ' &> /dev/null' if quiet
-        system cmd
+        sys(cmd)
       end
 
       # Show file path and guessed sequence type to the user and obtain a y/n


### PR DESCRIPTION
If a directory for NCBI BLAST+ is provided, the 'sys' method will set PATH to this directory before executing a shell command, if no other directory for PATH was provided.

Removed the redundant 'export_bin_dir' method that formerly set PATH to the NCBI BLAST+ directory.