### PR TITLE
Have the 'sys' method replace the 'export_bin_dir' method

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -93,7 +93,8 @@ module SequenceServer
       child_pid = fork do
         # Set the PATH environment variable to the binary directory or
         # safe directory.
-        ENV['PATH'] = config[:bin] || options[:path] || ENV['PATH']
+        ENV['PATH'] = config[:bin] if config[:bin] && !options[:path]
+        ENV['PATH'] = options[:path] if options[:path]
 
         # Change to the specified directory.
         Dir.chdir(options[:dir]) if options[:dir] && Dir.exist?(options[:dir])

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -250,14 +250,6 @@ module SequenceServer
       require config[:require]
     end
 
-    # Export NCBI BLAST+ bin dir to PATH environment variable.
-    def export_bin_dir
-      bin_dir = config[:bin]
-      return unless bin_dir
-      return if ENV['PATH'].split(':').include? bin_dir
-      ENV['PATH'] = "#{bin_dir}:#{ENV['PATH']}"
-    end
-
     def assert_blast_installed_and_compatible
       fail BLAST_NOT_INSTALLED unless command? 'blastdbcmd'
       version = `blastdbcmd -version`.split[1]

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -93,8 +93,7 @@ module SequenceServer
       child_pid = fork do
         # Set the PATH environment variable to the binary directory or
         # safe directory.
-        ENV['PATH'] = config[:bin] if config[:bin] && !options[:path]
-        ENV['PATH'] = options[:path] if options[:path]
+        ENV['PATH'] = config[:bin] || options[:path] || ENV['PATH']
 
         # Change to the specified directory.
         Dir.chdir(options[:dir]) if options[:dir] && Dir.exist?(options[:dir])

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -91,7 +91,9 @@ module SequenceServer
 
       # Fork.
       child_pid = fork do
-        # Set the PATH environment variable to the safe directory.
+        # Set the PATH environment variable to the binary directory or
+        # safe directory.
+        ENV['PATH'] = config[:bin] if config[:bin] && !options[:path]
         ENV['PATH'] = options[:path] if options[:path]
 
         # Change to the specified directory.
@@ -189,7 +191,6 @@ module SequenceServer
           fail BIN_DIR_NOT_FOUND, config[:bin]
         end
         logger.debug("Will use NCBI BLAST+ at: #{config[:bin]}")
-        export_bin_dir
       else
         logger.debug('Location of NCBI BLAST+ not provided. Assuming NCBI' \
                      ' BLAST+ to be present in: $PATH')


### PR DESCRIPTION
If a directory for NCBI BLAST+ is provided, the 'sys' method will set PATH to this directory before executing a shell command, if no other directory for PATH was provided.

Removed the redundant 'export_bin_dir' method that formerly set PATH to the NCBI BLAST+ directory.