### PR TITLE
Refactoring alignment

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -255,7 +255,7 @@ module SequenceServer
 
     def assert_blast_installed_and_compatible
       fail BLAST_NOT_INSTALLED unless command? 'blastdbcmd'
-      version = `blastdbcmd -version`.split[1]
+      version = sys('blastdbcmd -version')[0].chomp
       fail BLAST_NOT_EXECUTABLE if !$CHILD_STATUS.success? || version.empty?
       fail BLAST_NOT_COMPATIBLE, version unless version >= MINIMUM_BLAST_VERSION
     end
@@ -285,7 +285,7 @@ module SequenceServer
 
     # Return `true` if the given command exists and is executable.
     def command?(command)
-      system("which #{command} > /dev/null 2>&1")
+      (sys("which #{command}") rescue false) || true
     end
   end
 end

--- a/public/js/alignment_exporter.js
+++ b/public/js/alignment_exporter.js
@@ -23,14 +23,12 @@ export default class AlignmentExporter {
         var fasta = "";
 
         _.each(hsps, _.bind(function (hsp) {
-            fasta += hsp.query_id+" "+hsp.qstart+" "+hsp.qend+"\n";
-            fasta += hsp.hit_id+" "+hsp.sstart+" "+hsp.send+"\n";
+            fasta += ">"+hsp.query_id+":"+hsp.qstart+"-"+hsp.qend+"\n";
             fasta += hsp.qseq+"\n";
-            fasta += hsp.midline+"\n";
+            fasta += ">"+hsp.hit_id+":"+hsp.sstart+"-"+hsp.send+"\n";
             fasta += hsp.sseq+"\n";
-            // fasta += this.wrap_string(hsp.qseq, 80)+"\n";
-            // fasta += this.wrap_string(hsp.midline, 80)+"\n";
-            // fasta += this.wrap_string(hsp.sseq, 80)+"\n";
+            fasta += ">"+hsp.query_id+":"+hsp.qstart+"-"+hsp.qend+"_alignment_"+hsp.hit_id+":"+hsp.sstart+"-"+hsp.send+"\n";
+            fasta += hsp.midline+"\n";
         }, this));
         return fasta;
     }


### PR DESCRIPTION
Reformatted alignment exporter to make it multi-fasta-like.
Before it alignments exported in this format
```
SI2.2.0_02651 82 250
SI2.2.0_06160 1033 1183
FCDACKDGGELICCDKCPASYHLQCHYPAVDPTDIPNGEWLCYACRCASKREELLDEKGNEKKKRSALEVLTLAAALVNPREFELPKELQLPIMFPGSNKADYV---SGRRVGKSHCLDSNLMVPLPARLCFECGRSCRKAPLIACDYCPLYFHQDCLDPPLTAFPIG-RWMC
 C   +D   ++ CD C   +HL C  P +  T +P G+W C ACR      E+  ++  +K+KR   E+           E  L KE +        N+A  V         +    D      +  RL   C        LI CD C   +H +C+DPPL+  P G RW C
ICRRRRDAENMLLCDGCNRGHHLYCLKPKL--TAVPPGDWFCTACRPP----EIKPKEKTQKRKRFEDEI---------EDEPILTKETR-------QNRAKRVVHSDDEGEQEDDEDDEESEEDINIRLENLCATCKSGGKLIVCDTCSNRYHLECVDPPLSRSPRGRRWSC
SI2.2.0_02651 81 157
SI2.2.0_06160 1142 1213
DFCDACKDGGELICCDKCPASYHLQCHYPAVDPTDIPNG-EWLCYACRCASKREELLDEKGNEKKKRSALEVLTLAAA
+ C  CK GG+LI CD C   YHL+C  P +  +  P G  W C   +C +KR      +G EK++    E L  AAA
NLCATCKSGGKLIVCDTCSNRYHLECVDPPLSRS--PRGRRWSC--TKCKAKRRSTTKVRGREKERDK--ERLCAAAA
```

Reformatted it to this
```
>SI2.2.0_02651:82-250
FCDACKDGGELICCDKCPASYHLQCHYPAVDPTDIPNGEWLCYACRCASKREELLDEKGNEKKKRSALEVLTLAAALVNPREFELPKELQLPIMFPGSNKADYV---SGRRVGKSHCLDSNLMVPLPARLCFECGRSCRKAPLIACDYCPLYFHQDCLDPPLTAFPIG-RWMC
>SI2.2.0_06160:1033-1183
ICRRRRDAENMLLCDGCNRGHHLYCLKPKL--TAVPPGDWFCTACRPP----EIKPKEKTQKRKRFEDEI---------EDEPILTKETR-------QNRAKRVVHSDDEGEQEDDEDDEESEEDINIRLENLCATCKSGGKLIVCDTCSNRYHLECVDPPLSRSPRGRRWSC
>SI2.2.0_02651:82-250_alignment_SI2.2.0_06160:1033-1183
 C   +D   ++ CD C   +HL C  P +  T +P G+W C ACR      E+  ++  +K+KR   E+           E  L KE +        N+A  V         +    D      +  RL   C        LI CD C   +H +C+DPPL+  P G RW C
>SI2.2.0_02651:81-157
DFCDACKDGGELICCDKCPASYHLQCHYPAVDPTDIPNG-EWLCYACRCASKREELLDEKGNEKKKRSALEVLTLAAA
>SI2.2.0_06160:1142-1213
NLCATCKSGGKLIVCDTCSNRYHLECVDPPLSRS--PRGRRWSC--TKCKAKRRSTTKVRGREKERDK--ERLCAAAA
>SI2.2.0_02651:81-157_alignment_SI2.2.0_06160:1142-1213
+ C  CK GG+LI CD C   YHL+C  P +  +  P G  W C   +C +KR      +G EK++    E L  AAA
```
