### PR TITLE
Handle errors with class ENOENT rather than subclasses of ENOENT

### DIFF
--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -188,19 +188,6 @@ BANNER
 
         exit!
 
-      rescue SequenceServer::EXTENSION_FILE_NOT_FOUND => e
-
-        puts e
-
-        unless require?
-          puts 'You can set the correct value by running:'
-          puts
-          puts '  sequenceserver -s -r <value>'
-          puts
-        end
-
-        exit!
-
       rescue SequenceServer::BLAST_NOT_INSTALLED,
              SequenceServer::BLAST_NOT_EXECUTABLE,
              SequenceServer::BLAST_NOT_COMPATIBLE => e

--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -175,19 +175,6 @@ BANNER
         puts "Please consult sequenceserver --help for instructions on how to set the correct values."
         exit!
 
-      rescue SequenceServer::BIN_DIR_NOT_FOUND => e
-
-        puts e
-
-        unless bin?
-          puts 'You can set the correct value by running:'
-          puts
-          puts '  sequenceserver -s -b <value>'
-          puts
-        end
-
-        exit!
-
       rescue SequenceServer::DATABASE_DIR_NOT_FOUND => e
 
         puts e

--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -169,6 +169,12 @@ BANNER
         puts e
         exit!
 
+      rescue SequenceServer::ENOENT => e
+        puts e.to_s, ""
+
+        puts "Please consult sequenceserver --help for instructions on how to set the correct values."
+        exit!
+
       rescue SequenceServer::BIN_DIR_NOT_FOUND => e
 
         puts e

--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -170,7 +170,7 @@ BANNER
         exit!
 
       rescue SequenceServer::ENOENT => e
-        puts e.to_s, ""
+        puts e
 
         puts "Please consult sequenceserver --help for instructions on how to set the correct values."
         exit!

--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -175,19 +175,6 @@ BANNER
         puts "Please consult sequenceserver --help for instructions on how to set the correct values."
         exit!
 
-      rescue SequenceServer::DATABASE_DIR_NOT_FOUND => e
-
-        puts e
-
-        unless database_dir?
-          puts 'You can set the correct value by running:'
-          puts
-          puts '  sequenceserver -s -d <value>'
-          puts
-        end
-
-        exit!
-
       rescue SequenceServer::NUM_THREADS_INCORRECT => e
 
         puts e

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -191,7 +191,7 @@ module SequenceServer
       if config[:bin]
         config[:bin] = File.expand_path config[:bin]
         unless File.exist?(config[:bin]) && File.directory?(config[:bin])
-          fail BIN_DIR_NOT_FOUND, config[:bin]
+          fail ENOENT.new("bin dir", config[:bin])
         end
         logger.debug("Will use NCBI BLAST+ at: #{config[:bin]}")
       else

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -208,7 +208,7 @@ module SequenceServer
       config[:database_dir] = File.expand_path(config[:database_dir])
       unless File.exist?(config[:database_dir]) &&
              File.directory?(config[:database_dir])
-        fail DATABASE_DIR_NOT_FOUND, config[:database_dir]
+        fail ENOENT.new("database dir", config[:database_dir])
       end
 
       logger.debug("Will use BLAST+ databases at: #{config[:database_dir]}")

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -246,7 +246,7 @@ module SequenceServer
 
       config[:require] = File.expand_path config[:require]
       unless File.exist?(config[:require]) && File.file?(config[:require])
-        fail EXTENSION_FILE_NOT_FOUND, config[:require]
+        fail ENOENT.new("extension file", config[:require])
       end
 
       logger.debug("Loading extension: #{config[:require]}")

--- a/lib/sequenceserver/exceptions.rb
+++ b/lib/sequenceserver/exceptions.rb
@@ -52,13 +52,6 @@ MSG
     end
   end
 
-  # Raised if extension file set, but does not exist.
-  class EXTENSION_FILE_NOT_FOUND < ENOENT
-    def initialize(ent)
-      super 'extension file', ent
-    end
-  end
-
   ## NUM THREADS ##
 
   # Raised if num_threads set by the user is incorrect.

--- a/lib/sequenceserver/exceptions.rb
+++ b/lib/sequenceserver/exceptions.rb
@@ -52,13 +52,6 @@ MSG
     end
   end
 
-  # Raised if bin dir set, but does not exist.
-  class BIN_DIR_NOT_FOUND < ENOENT
-    def initialize(ent)
-      super 'bin dir', ent
-    end
-  end
-
   # Raised if database dir set, but does not exist.
   class DATABASE_DIR_NOT_FOUND < ENOENT
     def initialize(ent)

--- a/lib/sequenceserver/exceptions.rb
+++ b/lib/sequenceserver/exceptions.rb
@@ -52,13 +52,6 @@ MSG
     end
   end
 
-  # Raised if database dir set, but does not exist.
-  class DATABASE_DIR_NOT_FOUND < ENOENT
-    def initialize(ent)
-      super 'database dir', ent
-    end
-  end
-
   # Raised if extension file set, but does not exist.
   class EXTENSION_FILE_NOT_FOUND < ENOENT
     def initialize(ent)


### PR DESCRIPTION
The class ENOENT in lib/sequenceserver/exceptions.rb is the superclass of classes BIN_DIR_NOT_FOUND; DATABASE_DIR_NOT_FOUND; EXTENSION_FILE_NOT_FOUND. Handle errors with class ENOENT rather than the subclasses of ENOENT.