### PR TITLE
query params for /searchdata.json

### DIFF
--- a/lib/sequenceserver/routes.rb
+++ b/lib/sequenceserver/routes.rb
@@ -64,37 +64,44 @@ module SequenceServer
     # Returns data that is used to render the search form client side. These
     # include available databases and user-defined search options.
     get '/searchdata.json' do
-      sequences = ['']
+      searchdata = {
+        database: Database.all,
+        options: SequenceServer.config[:options]
+      }
       if params[:query]
         # if the url contains a query param (query=seqid1:start-stop,seqid2:start-stop)
         # parse the sequence ids and retrieve the sequences to be added to the textarea
         # by updating query state in search.js.
         #
-        # Have to check both database types as we don't know what type of id we have
-        # but if one protein match is found we don't look for nucleotide matches.
+        # Have to check both database types as we don't know what type of id we have and
+        # blastdbcmd throws an error if given a set of databases with mixed type.
         #
-        # Location parameters in the query string are currently just ignored.
-        sequences = params[:query].split(',')
-        sequence_ids = sequences.map { |x| x.split(':')[0] }
+        # Loop through query sequences one-by-one to allow us to specify range and catch
+        # individual identifiers that cannot be found.
         databases = Database.all.select { |x| x.type == 'protein' }
-        database_ids = databases.map { |x| x.id }
-        begin
-          retrieved_seqs = Sequence::Retriever.new(sequence_ids, database_ids)
-          sequences = retrieved_seqs.sequences.map { |x| '>' + x.id + "\n" + x.value }
-        rescue
+        protein_database_ids = databases.map { |x| x.id }
+        databases = Database.all.select { |x| x.type == 'nucleotide' }
+        nucleotide_database_ids = databases.map { |x| x.id }
+        retrieved_seqs = {}
+        sequences = params[:query].split(',')
+        sequences.each do |sequence|
+          sequence_id,range = sequence.split(':')
+          new_seqs = {}
           begin
-            databases = Database.all.select { |x| x.type == 'nucleotide' }
-            database_ids = databases.map { |x| x.id }
-            retrieved_seqs = Sequence::Retriever.new(sequence_ids, database_ids)
-            sequences = retrieved_seqs.sequences.map { |x| '>' + x.id + "\n" + x.value }
+            new_seqs = Sequence::Retriever.new(sequence_id, protein_database_ids,false,range).to_hash
+          rescue
+            begin
+              new_seqs = Sequence::Retriever.new(sequence_id, nucleotide_database_ids,false,range).to_hash
+            rescue
+              # will get here if no sequence matched the provided identifier
+              new_seqs = { :error_msgs=> [ "You requested a sequence with the identifier "+sequence_id+" but no matching sequences were found." ] }
+            end
           end
+          retrieved_seqs = retrieved_seqs.merge( new_seqs ){ |k,a,b| a + b }
         end
+        searchdata = searchdata.merge( { query: retrieved_seqs } )
       end
-      {
-        database: Database.all,
-        options:  SequenceServer.config[:options],
-        query: sequences
-      }.to_json
+      searchdata.to_json
     end
 
     # Queues a search job and redirects to `/:jid`.

--- a/lib/sequenceserver/sequence.rb
+++ b/lib/sequenceserver/sequence.rb
@@ -164,15 +164,16 @@ module SequenceServer
         end
       end
 
-      def initialize(sequence_ids, database_ids, in_file = false)
+      def initialize(sequence_ids, database_ids, in_file = false, range = false)
         @sequence_ids = Array sequence_ids
         @database_ids = Array database_ids
         @in_file = in_file
+        @range = range
 
         validate && run
       end
 
-      attr_reader :sequence_ids, :database_ids, :in_file
+      attr_reader :sequence_ids, :database_ids, :in_file, :range
 
       attr_reader :sequences
 
@@ -183,12 +184,21 @@ module SequenceServer
         }.to_json
       end
 
+      def to_hash
+        {
+          :error_msgs => error_msgs,
+          :sequences  => sequences.map(&:info)
+        }
+      end
+
       private
 
       def run
         command = "blastdbcmd -outfmt '%g	%i	%a	%t	%s'" \
                   " -db '#{database_names.join(' ')}'" \
                   " -entry '#{sequence_ids.join(',')}'"
+
+        command += " -range '#{range}'" if range
 
         out, _ = sys(command)
 
@@ -238,6 +248,7 @@ MSG
         ]
       end
       # rubocop:enable Metrics/MethodLength
+
     end
   end
 end

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -793,13 +793,22 @@ var Form = React.createClass({
      };
     },
 
+    formatQuerySequences: function (retrieved_seqs) {
+      if (retrieved_seqs.hasOwnProperty("sequences")) {
+        return retrieved_seqs.sequences.map(function (x) {
+          return '>' + x.id + "\r\n" + x.value
+        }).join("\r\n");
+      }
+      return [];
+    },
+
     componentDidMount: function () {
        $.getJSON("searchdata.json"+window.location.search, _.bind(function(data) {
          this.setState({
             preDefinedOpts: data["options"],
             databases: data["database"]
          });
-         this.refs.query.value(data["query"]);
+         this.refs.query.value(this.formatQuerySequences(data["query"]));
        }, this));
 
        $(document).bind("keydown", _.bind(function (e) {

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -281,7 +281,7 @@ var Query = React.createClass({
      * of directly calling this method.
      */
     type: function () {
-        var sequences = this.value().split(/>.*/);
+        var sequences = this.value().toString().split(/>.*/);
 
         var type, tmp;
 
@@ -794,11 +794,12 @@ var Form = React.createClass({
     },
 
     componentDidMount: function () {
-       $.getJSON("searchdata.json", _.bind(function(data) {
+       $.getJSON("searchdata.json"+window.location.search, _.bind(function(data) {
          this.setState({
             preDefinedOpts: data["options"],
             databases: data["database"]
          });
+         this.refs.query.value(data["query"]);
        }, this));
 
        $(document).bind("keydown", _.bind(function (e) {
@@ -863,7 +864,7 @@ var Form = React.createClass({
     },
 
     handleAlgoChanged: function (algo) {
-      if (this.state.preDefinedOpts.hasOwnProperty(algo)) {
+      if (this.state.preDefinedOpts && this.state.preDefinedOpts.hasOwnProperty(algo)) {
         this.refs.opts.setState({
           preOpts: this.state.preDefinedOpts[algo].join(" ")
         });


### PR DESCRIPTION
I've added support for passing in query params like `query=seqid1,seqid2` via `searchdata.json` to prepopulate the textarea with sequences from the blast databases.

params can also be specified as `query=seqid1:start-stop,seqid2:start-stop` but for now the location information is just ignored.