### PR TITLE
Updated to sinatra 2

### DIFF
--- a/sequenceserver.gemspec
+++ b/sequenceserver.gemspec
@@ -17,12 +17,12 @@ interface for use locally or over the web.
 DESC
 
   # dependencies
-  s.add_dependency('sinatra',   '~> 1.4',  '>= 1.4.5')
+  s.add_dependency('sinatra',   '~> 2.0',  '>= 2.0')
   s.add_dependency('json_pure', '~> 1.8',  '>= 1.8.2')
   s.add_dependency('ox',        '~> 2.1',  '>= 2.1.1')
   s.add_dependency('slop',      '~> 3.6',  '>= 3.6.0')
 
-  s.add_development_dependency('rack-test',       '~> 0.6',  '>= 0.6.2')
+  s.add_development_dependency('rack-test',       '~> 0.8',  '>= 0.8.2')
   s.add_development_dependency('rspec',           '~> 2.8',  '>= 2.8.0')
   s.add_development_dependency('rake',            '~> 10.3', '>= 10.3.2')
   s.add_development_dependency('rubocop',         '~> 0.31', '>= 0.31.0')


### PR DESCRIPTION
Hi, 
I made this minor update to update to Sinatra 2.0, since I'm integrating sequence server with a Rails 5, and 1.4 is not supported for Rails 5. It seems to be working. 
Best, 
Ricardo.  