### PR TITLE
circos error message updated when no hits found

### DIFF
--- a/public/js/report.js
+++ b/public/js/report.js
@@ -1061,10 +1061,7 @@ var Report = React.createClass({
                     { this.isHitsAvailable() 
                     ? <Circos queries={this.state.queries}
                         program={this.state.program} collapsed="true"/> 
-                    : <div
-                    className="section-content">
-                        <strong> ****** No hits found ****** </strong><br/><br/>
-                    </div> }
+                    : <span></span> }
                     {
                         _.map(this.state.queries, _.bind(function (query) {
                             return (

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -1004,6 +1004,14 @@ var Report = React.createClass({
         return this.state.queries.length >= 1;
     },
 
+    isHitsAvailable: function () {
+        var cnt = 0;
+        _.each(this.state.queries, function (query) {
+            if(query.hits.length == 0) cnt++;
+        });
+        return !(cnt == this.state.queries.length);
+    },
+
     /**
      * Returns loading message
      */
@@ -1050,8 +1058,13 @@ var Report = React.createClass({
                 <div className={this.shouldShowSidebar() ?
                     'col-md-9' : 'col-md-12'}>
                     { this.overview() }
-                    <Circos queries={this.state.queries}
-                        program={this.state.program} collapsed="true"/>
+                    { this.isHitsAvailable() 
+                    ? <Circos queries={this.state.queries}
+                        program={this.state.program} collapsed="true"/> 
+                    : <div
+                    className="section-content">
+                        <strong> ****** No hits found ****** </strong><br/><br/>
+                    </div> }
                     {
                         _.map(this.state.queries, _.bind(function (query) {
                             return (


### PR DESCRIPTION
Previously when no hits are found the Circos error messages was not appropriate.
![screen shot 2018-05-24 at 16 40 07](https://user-images.githubusercontent.com/7463217/40500094-6e55100a-5fa1-11e8-9c3e-16acf69187e3.png)
Therefore I added a condition to make it look similar to others.
![screen shot 2018-05-24 at 16 40 50](https://user-images.githubusercontent.com/7463217/40500177-a3097ac0-5fa1-11e8-9e85-255d6f5a6544.png)

