### PR TITLE
Add links to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please see http://sequenceserver.com.
 
 ## Develop and contribute
 
-You will need Ruby and RubyGems, Node and npm, and CodeClimate. Further, please
+You will need [Ruby](https://www.ruby-lang.org/en/) and [RubyGems](https://rubygems.org/), [Node and npm](https://nodejs.org/), and [CodeClimate](https://codeclimate.com/). Further, please
 note that **`1.0.x` branch contains the stable releases, while the `master`
 branch is a work in progress towards next release and may be buggy**.
 


### PR DESCRIPTION
Hello sequenceserver team,

As a first time visitor to your repository, I figured it might be helpful to direct your users to the required dependencies with links to their respective homepages. This takes out the extra steps of them having to search each dependency.

In the interest of full transparency, this edit is for an assignment for a university technical writing course. A higher grade will be rewarded if PRs are approved. Please let me know if there are any issues with this PR that could be rectified, or any further additions I can make, in order to achieve an approval.

Much obliged,
-Correy
