### PR TITLE
Ability to pre-populate textarea with server-sent query sequences

### DIFF
--- a/lib/sequenceserver/database.rb
+++ b/lib/sequenceserver/database.rb
@@ -36,6 +36,19 @@ module SequenceServer
 
     attr_reader :id
 
+    def [](accession, coords = nil)
+      cmd = "blastdbcmd -db #{name} -entry '#{accession}'"
+      if coords
+        cmd << " -range #{coords}"
+      end
+      out, = sys(cmd, path: config[:bin])
+      out.chomp
+    rescue CommandFailed
+      # Command failed beacuse stdout was empty, meaning accession not
+      # present in this database.
+      nil
+    end
+
     def include?(accession)
       cmd = "blastdbcmd -entry '#{accession}' -db #{name}"
       out, = sys(cmd, path: config[:bin])
@@ -101,6 +114,64 @@ module SequenceServer
 
       def to_json
         collection.values.to_json
+      end
+
+      # Retrieve given loci from the databases we have.
+      #
+      # loci to retrieve are specified as a String:
+      #
+      #    "accession_1,accession_2:start-stop,accession_3"
+      #
+      # Return value is a FASTA format String containing sequences in the same
+      # order in which they were requested. If an accession could not be found,
+      # a commented out error message is included in place of the sequence.
+      # Sequences are retrieved from the first database in which the accession
+      # is found. The returned sequences can, thus, be incorrect if accessions
+      # are not unique across all database (admins should make sure of that).
+      def retrieve(loci)
+        # Exit early if loci is nil.
+        return unless loci
+
+        # String -> Array
+        # We may have empty string if loci contains a double comma as a result
+        # of typo (remember - loci is external input). These are eliminated.
+        loci = loci.split(',').delete_if(&:empty?)
+
+        # Each database is searched for each locus. For each locus, search is
+        # terminated on the first database match.
+        # NOTE: This can return incorrect sequence if the sequence ids are
+        # not unique across all databases.
+        seqs = loci.map do |locus|
+          # Get sequence id and coords. coords may be nil. accession can't
+          # be.
+          accession, coords = locus.split(':')
+
+          # Initialise a variable to store retrieved sequence.
+          seq = nil
+
+          # Go over each database looking for this accession.
+          each do |database|
+            # Database lookup  will return a string if given accession is
+            # present in the database, nil otherwise.
+            seq = database[accession, coords]
+            # Found a match! Terminate iteration returning the retrieved
+            # sequence.
+            break if seq
+          end
+
+          # If accession was not present in any database, insert an error
+          # message in place of the sequence. The line starts with '#'
+          # and should be ignored by BLAST (not tested).
+          unless seq
+            seq = "# ERROR: #{locus} not found in any database"
+          end
+
+          # Return seq.
+          seq
+        end
+
+        # Array -> String
+        seqs.join("\n")
       end
 
       # Intended to be used only for testing.

--- a/lib/sequenceserver/routes.rb
+++ b/lib/sequenceserver/routes.rb
@@ -62,10 +62,12 @@ module SequenceServer
     # Returns data that is used to render the search form client side. These
     # include available databases and user-defined search options.
     get '/searchdata.json' do
-      {
+      searchdata = {
         database: Database.all,
-        options:  SequenceServer.config[:options]
-      }.to_json
+        options: SequenceServer.config[:options],
+        query: Database.retrieve(params[:query])
+      }
+      searchdata.to_json
     end
 
     # Queues a search job and redirects to `/:jid`.

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -201,12 +201,25 @@ var Form = React.createClass({
     },
 
     componentDidMount: function () {
-        $.getJSON("searchdata.json", _.bind(function(data) {
+        /* Fetch data to initialise the search interface from the server. These
+         * include list of databases to search against, advanced options to
+         * apply when an algorithm is selected, and a query sequenced that
+         * the user may want to search in the databases.
+         */
+        $.getJSON("searchdata.json" + window.location.search, function(data) {
+            /* Update form state (i.e., list of databases and predefined
+             * advanced options.
+             */
             this.setState({
                 databases: data["database"], preDefinedOpts: data["options"]
             });
-        }, this));
 
+            /* Pre-populate the form with server sent query sequence.
+             */
+            this.refs.query.value(data["query"]);
+        }.bind(this));
+
+        /* Enable submitting form on Cmd+Enter */
        $(document).bind("keydown", _.bind(function (e) {
            if (e.ctrlKey && e.keyCode === 13 &&
                !$('#method').is(':disabled')) {


### PR DESCRIPTION
API is the same as proposed in PR #332. Although our implementation differs considerably, code and ideas were borrowed from the original PR.

To test this feature, run SequenceServer in development mode (`-D`). The example below uses the sample database included with SequenceServer.

```
# git clone, fetch, etc. Then,
cd sequenceserver
bundle exec bin/sequenceserver -D -d spec/database/sample
```

Now visit http://localhost:4567/?query=SI2.2.0_06267,foo,SI2.2.0_13722:1-10,SI2.2.0_80257:a-b.

Each database is searched for each locus. The search is stopped once a hit is found. In future, it may be worth memoizing the database in which a given locus was found.

/cc @rjchallis 