### PR TITLE
CSS fix for appearing scrollbar

### DIFF
--- a/public/css/sequenceserver.css
+++ b/public/css/sequenceserver.css
@@ -235,6 +235,8 @@ a.disabled:hover,
   padding: 0;
   border-radius: 0;
   background-color: inherit;
+  white-space: pre-wrap;
+  word-break: keep-all;
 }
 
 /***************************


### PR DESCRIPTION
New CSS properties was added to the pre tag for the text field on top of
the page in order to remove the appearing scrollbar, which appears when
the list of the used databases for query is  > 3.

Signed-off-by: Iwo Pieniak <ivo.pieniak@gmail.com>