### PR TITLE
CSS fix of the .hit-links buttons and links.

### DIFF
--- a/public/css/sequenceserver.css
+++ b/public/css/sequenceserver.css
@@ -317,6 +317,10 @@ input[name="advanced"] {
   border-bottom-left-radius: 4px !important;
 }
 
+input[type=checkbox] {
+  vertical-align: top;
+}
+
 #method {
   letter-spacing: 1px;
 }
@@ -435,6 +439,7 @@ input[name="advanced"] {
 .hit-links * {
   padding-left: 3px;
   letter-spacing: 1px;
+  vertical-align: baseline;
 }
 .btn-link {
   border: none;


### PR DESCRIPTION
Applied the vertical-align property to the checkbox + vertical-align to
the .hit-links class. The only potential improvement for the future is
to upgrade the FA icon of the link (Uniprot i.e.) to the newer version,
as those are identically sized in the newest versions.

Signed-off-by: Iwo Pieniak <ivo.pieniak@gmail.com>