### PR TITLE
X and Y axis outer tick fix

### DIFF
--- a/public/js/length_distribution.js
+++ b/public/js/length_distribution.js
@@ -64,8 +64,8 @@ class Graph {
         this._scale_x = d3.scale.linear()
             .domain([
                 0,
-                (d3.max([this.query_length,d3.max(this._data)]) * 1.05)
-            ])
+                (d3.max([this.query_length, d3.max(this._data)]) * 1.01)
+            ]).nice()
             .range([0, this._width]);
         this._bins = d3.layout.histogram()
             .range(this._scale_x.domain())
@@ -73,7 +73,7 @@ class Graph {
             (this._data);
         this._scale_y = d3.scale.linear()
             .domain([0, d3.max(this._bins, function(d) { return d.length; })])
-            .range([this._height, 0]);
+            .range([this._height, 0]).nice();
     }
 
     hit_lengths() {
@@ -215,6 +215,7 @@ class Graph {
             .scale(this._scale_y)
             .orient('left')
             .tickValues(this._scale_y.ticks(space))
+            .outerTickSize(0)
             .tickFormat(function (e) {
                 if (Math.floor(e) != e) {
                     return ;


### PR DESCRIPTION
For the both axes we call the nice() function which rounds up the domain
to the nice value which is either 2,5, or multiples of 10. Effectively
it rounds up to the next major tick, which is what we desired from the
begining.

To remove the annoying outerTick from the Y-axis outerTickSize attribute
is set to 0 to simply remove it. In some situations, the last tick on
the Y-axis will be also the outer-tick as these can overlay. Apart from
this case, consistently the outer tick will not be present in the
y-axis.

Signed-off-by: Iwo Pieniak <ivo.pieniak@gmail.com>