### PR TITLE
Travis fix

### DIFF
--- a/spec/blast_versions/blast_2.2.30/import_spec_capybara_local_2.2.30.rb
+++ b/spec/blast_versions/blast_2.2.30/import_spec_capybara_local_2.2.30.rb
@@ -1,12 +1,16 @@
 describe 'report generated from imported XML', type: :feature, js: true do
-  # Test suite to test features of imported XML report.
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility. Each query was limited to 20 hits to not to overload the test suite.
-  # BLAST 2.2.30 displays hits in a different order than versions 2.2.31 upwards for protein queries (BLASTP, TBLASTN), hence the test takes different files for comparison.
+  # Test suite to test features of imported XML report. Fasta files used for
+  # testing consist of TP53 and COX41 protein/nucleotide sequences for
+  # reproducibility. Each query was limited to 20 hits to not to overload the
+  # test suite. BLAST 2.2.30 displays hits in a different order than versions
+  # 2.2.31 upwards for protein queries (BLASTP, TBLASTN), hence the test takes
+  # different files for comparison.
 
   # BLASTP test scenarios
   it 'loads BLASTP XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.30/blastp')
-    # Click on the first hit Alignment download button on the page and wait for the download to finish.
+    # Click on the first hit Alignment download button on the page and wait for
+    # the download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -15,7 +19,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -24,7 +29,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -40,7 +46,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests alignment overiview and hit PNG/SVG download' do
     access_by_uuid('blast_2.2.30/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -54,7 +61,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_120407068_ref_NP_000537_3.png')
@@ -70,8 +78,10 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Circos download' do
     access_by_uuid('blast_2.2.30/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
-    page.should have_content('Circos')
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -88,7 +98,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.30/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
     sleep 1
@@ -109,7 +121,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.30/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
@@ -117,7 +130,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -126,7 +140,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
     page.check('Query_2_hit_3_checkbox')
@@ -143,7 +158,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.2.30/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -156,7 +172,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
@@ -171,9 +188,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.2.30/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -189,7 +208,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.30/blastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -211,7 +232,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.30/blastn')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -220,7 +242,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -229,7 +252,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_5_checkbox')
     page.check('Query_1_hit_6_checkbox')
     page.check('Query_2_hit_5_checkbox')
@@ -245,7 +269,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.2.30/blastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -257,7 +282,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(2)').click()")
     wait_for_download
@@ -265,7 +291,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(2)').click()")
     wait_for_download
@@ -275,9 +302,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.2.30/blastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -293,7 +322,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.30/blastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -314,7 +345,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.30/tblastn')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -323,7 +355,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -332,7 +365,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_7_checkbox')
     page.check('Query_1_hit_8_checkbox')
     page.check('Query_2_hit_7_checkbox')
@@ -348,7 +382,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTN XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.2.30/tblastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -362,7 +397,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -370,7 +406,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -380,9 +417,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.2.30/tblastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -399,7 +438,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.30/tblastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -420,7 +461,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.30/tblastx')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(1)').click()")
     wait_for_download
@@ -429,7 +471,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -438,7 +481,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_9_checkbox')
     page.check('Query_1_hit_10_checkbox')
     page.check('Query_2_hit_9_checkbox')
@@ -454,7 +498,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.2.30/tblastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -467,7 +512,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -475,7 +521,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -485,9 +532,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.2.30/tblastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -504,7 +553,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.30/tblastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/blast_versions/blast_2.2.31/import_spec_capybara_local_2.2.31.rb
+++ b/spec/blast_versions/blast_2.2.31/import_spec_capybara_local_2.2.31.rb
@@ -1,12 +1,15 @@
 describe 'report generated from imported XML', type: :feature, js: true do
-  # Test suite to test features of imported XML report.
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility. Each query was limited to 20 hits to not to overload the test suite.
+  # Test suite to test features of imported XML report. Fasta files used for
+  # testing consist of TP53 and COX41 protein/nucleotide sequences for
+  # reproducibility. Each query was limited to 20 hits to not to overload the
+  # test suite.
 
   # BLASTP test scenarios
   it 'loads BLASTP XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.31/blastp')
 
-    # Click on the first hit Alignment download button on the page and wait for the download to finish.
+    # Click on the first hit Alignment download button on the page and wait for
+    # the download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -16,7 +19,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -26,7 +30,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -42,7 +47,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.2.31/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -56,7 +62,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -73,9 +80,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Circos download' do
     access_by_uuid('blast_2.2.31/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -93,7 +102,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.31/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -115,7 +126,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.31/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -125,7 +137,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -134,7 +147,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
 
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
@@ -152,7 +166,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.2.31/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -165,7 +180,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
@@ -180,9 +196,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.2.31/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -198,7 +216,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.31/blastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -219,7 +239,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.31/blastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -228,7 +249,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -237,7 +259,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_5_checkbox')
     page.check('Query_1_hit_6_checkbox')
     page.check('Query_2_hit_5_checkbox')
@@ -253,7 +276,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.2.31/blastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -265,7 +289,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(2)').click()")
     wait_for_download
@@ -273,7 +298,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(2)').click()")
     wait_for_download
@@ -284,9 +310,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.2.31/blastn')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -302,7 +330,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.31/blastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -322,7 +352,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.31/tblastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -331,7 +362,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -340,7 +372,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_7_checkbox')
     page.check('Query_1_hit_8_checkbox')
     page.check('Query_2_hit_7_checkbox')
@@ -356,7 +389,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.2.31/tblastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
@@ -367,7 +401,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -375,7 +410,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -385,9 +421,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.2.31/tblastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -404,7 +442,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.31/tblastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -425,7 +465,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.2.31/tblastx')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(1)').click()")
     wait_for_download
@@ -434,7 +475,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -443,7 +485,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_9_checkbox')
     page.check('Query_1_hit_10_checkbox')
     page.check('Query_2_hit_9_checkbox')
@@ -459,7 +502,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.2.31/tblastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -471,7 +515,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -479,7 +524,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -490,9 +536,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.2.31/tblastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -509,7 +557,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.2.31/tblastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/blast_versions/blast_2.3.0/import_spec_capybara_local_2.3.0.rb
+++ b/spec/blast_versions/blast_2.3.0/import_spec_capybara_local_2.3.0.rb
@@ -1,12 +1,15 @@
 describe 'report generated from imported XML', type: :feature, js: true do
-  # Test suite to test features of imported XML report.
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility. Each query was limited to 20 hits to not to overload the test suite.
+  # Test suite to test features of imported XML report. Fasta files used for
+  # testing consist of TP53 and COX41 protein/nucleotide sequences for
+  # reproducibility. Each query was limited to 20 hits to not to overload the
+  # test suite.
 
   # BLASTP test scenarios
   it 'loads BLASTP XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.3.0/blastp')
 
-    # Click on the first hit Alignment download button on the page and wait for the download to finish.
+    # Click on the first hit Alignment download button on the page and wait for
+    # the download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -16,7 +19,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -26,7 +30,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -42,7 +47,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.3.0/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -56,7 +62,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -73,9 +80,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Circos download' do
     access_by_uuid('blast_2.3.0/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -93,7 +102,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('blast_2.3.0/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -115,7 +126,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.3.0/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -125,7 +137,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -134,7 +147,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
 
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
@@ -152,7 +166,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.3.0/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -165,7 +180,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
@@ -180,9 +196,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.3.0/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -198,7 +216,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.3.0/blastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -219,7 +239,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.3.0/blastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -228,7 +249,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -237,7 +259,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_5_checkbox')
     page.check('Query_1_hit_6_checkbox')
     page.check('Query_2_hit_5_checkbox')
@@ -253,7 +276,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.3.0/blastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -265,7 +289,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(2)').click()")
     wait_for_download
@@ -273,7 +298,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(2)').click()")
     wait_for_download
@@ -284,9 +310,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.3.0/blastn')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -302,7 +330,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.3.0/blastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -322,7 +352,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.3.0/tblastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -331,7 +362,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -340,7 +372,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_7_checkbox')
     page.check('Query_1_hit_8_checkbox')
     page.check('Query_2_hit_7_checkbox')
@@ -356,7 +389,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.3.0/tblastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
@@ -367,7 +401,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -375,7 +410,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -385,9 +421,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.3.0/tblastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -404,7 +442,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.3.0/tblastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -425,7 +465,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.3.0/tblastx')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(1)').click()")
     wait_for_download
@@ -434,7 +475,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -443,7 +485,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_9_checkbox')
     page.check('Query_1_hit_10_checkbox')
     page.check('Query_2_hit_9_checkbox')
@@ -459,7 +502,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.3.0/tblastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -471,7 +515,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -479,7 +524,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -490,9 +536,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.3.0/tblastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -509,7 +557,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.3.0/tblastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/blast_versions/blast_2.4.0/import_spec_capybara_local_2.4.0.rb
+++ b/spec/blast_versions/blast_2.4.0/import_spec_capybara_local_2.4.0.rb
@@ -1,11 +1,14 @@
 describe 'report generated from imported XML', type: :feature, js: true do
-  # Test suite to test features of imported XML report.
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility. Each query was limited to 20 hits to not to overload the test suite.
+  # Test suite to test features of imported XML report. Fasta files used for
+  # testing consist of TP53 and COX41 protein/nucleotide sequences for
+  # reproducibility. Each query was limited to 20 hits to not to overload the
+  # test suite.
 
   # BLASTP test scenarios
   it 'loads BLASTP XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.4.0/blastp')
-    # Click on the first hit Alignment download button on the page and wait for the download to finish.
+    # Click on the first hit Alignment download button on the page and wait for
+    # the download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -15,7 +18,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -24,7 +28,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/alignment-40_hits_blastp.txt'))
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -40,7 +45,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.4.0/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -54,7 +60,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
 
@@ -71,8 +78,10 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Circos download' do
     access_by_uuid('blast_2.4.0/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
-    page.should have_content('Circos')
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -89,7 +98,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('blast_2.4.0/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
     sleep 1
@@ -109,7 +120,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.4.0/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
 
@@ -118,7 +130,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -127,7 +140,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/alignment-40_hits_blastx.txt'))
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
     page.check('Query_2_hit_3_checkbox')
@@ -144,7 +158,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.4.0/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -156,7 +171,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
 
     wait_for_download
@@ -172,9 +188,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.4.0/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -190,7 +208,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.4.0/blastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -211,7 +231,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.4.0/blastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -221,7 +242,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -231,7 +253,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_5_checkbox')
     page.check('Query_1_hit_6_checkbox')
     page.check('Query_2_hit_5_checkbox')
@@ -247,7 +270,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.4.0/blastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -259,7 +283,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(2)').click()")
 
@@ -268,7 +293,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(2)').click()")
     wait_for_download
@@ -279,9 +305,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.4.0/blastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -297,7 +325,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.4.0/blastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -316,7 +346,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.4.0/tblastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -326,7 +357,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -336,7 +368,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_7_checkbox')
     page.check('Query_1_hit_8_checkbox')
     page.check('Query_2_hit_7_checkbox')
@@ -352,7 +385,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.4.0/tblastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
@@ -364,7 +398,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
 
@@ -372,7 +407,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.png')
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -383,9 +419,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.4.0/tblastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -402,7 +440,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.4.0/tblastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -423,7 +463,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.4.0/tblastx')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(1)').click()")
     wait_for_download
@@ -433,7 +474,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -443,7 +485,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_9_checkbox')
     page.check('Query_1_hit_10_checkbox')
     page.check('Query_2_hit_9_checkbox')
@@ -459,7 +502,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.4.0/tblastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -471,7 +515,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
 
@@ -480,7 +525,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -491,9 +537,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.4.0/tblastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -510,7 +558,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.4.0/tblastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/blast_versions/blast_2.5.0/import_spec_capybara_local_2.5.0.rb
+++ b/spec/blast_versions/blast_2.5.0/import_spec_capybara_local_2.5.0.rb
@@ -1,12 +1,15 @@
 describe 'report generated from imported XML', type: :feature, js: true do
-  # Test suite to test features of imported XML report.
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility. Each query was limited to 20 hits to not to overload the test suite.
+  # Test suite to test features of imported XML report. Fasta files used for
+  # testing consist of TP53 and COX41 protein/nucleotide sequences for
+  # reproducibility. Each query was limited to 20 hits to not to overload the
+  # test suite.
 
   # BLASTP test scenarios
   it 'loads BLASTP XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.5.0/blastp')
 
-    # Click on the first hit Alignment download button on the page and wait for the download to finish.
+    # Click on the first hit Alignment download button on the page and wait for
+    # the download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -16,7 +19,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -26,7 +30,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -42,7 +47,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.5.0/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -56,7 +62,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -73,9 +80,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Circos download' do
     access_by_uuid('blast_2.5.0/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -93,7 +102,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('blast_2.5.0/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -115,7 +126,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.5.0/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -125,7 +137,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -134,7 +147,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
 
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
@@ -152,7 +166,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.5.0/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -165,7 +180,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
@@ -180,9 +196,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.5.0/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -198,7 +216,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.5.0/blastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -219,7 +239,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.5.0/blastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -228,7 +249,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -237,7 +259,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_5_checkbox')
     page.check('Query_1_hit_6_checkbox')
     page.check('Query_2_hit_5_checkbox')
@@ -253,7 +276,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.5.0/blastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -265,7 +289,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(2)').click()")
     wait_for_download
@@ -273,7 +298,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(2)').click()")
     wait_for_download
@@ -284,9 +310,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.5.0/blastn')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -302,7 +330,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.5.0/blastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -322,7 +352,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.5.0/tblastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -331,7 +362,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -340,7 +372,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_7_checkbox')
     page.check('Query_1_hit_8_checkbox')
     page.check('Query_2_hit_7_checkbox')
@@ -356,7 +389,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.5.0/tblastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
@@ -367,7 +401,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -375,7 +410,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -385,9 +421,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.5.0/tblastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -404,7 +442,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.5.0/tblastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -425,7 +465,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.5.0/tblastx')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(1)').click()")
     wait_for_download
@@ -434,7 +475,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -443,7 +485,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_9_checkbox')
     page.check('Query_1_hit_10_checkbox')
     page.check('Query_2_hit_9_checkbox')
@@ -459,7 +502,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.5.0/tblastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -471,7 +515,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -479,7 +524,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -490,9 +536,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.5.0/tblastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -509,7 +557,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.5.0/tblastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/blast_versions/blast_2.6.0/import_spec_capybara_local_2.6.0.rb
+++ b/spec/blast_versions/blast_2.6.0/import_spec_capybara_local_2.6.0.rb
@@ -1,12 +1,15 @@
 describe 'report generated from imported XML', type: :feature, js: true do
-  # Test suite to test features of imported XML report.
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility. Each query was limited to 20 hits to not to overload the test suite.
+  # Test suite to test features of imported XML report. Fasta files used for
+  # testing consist of TP53 and COX41 protein/nucleotide sequences for
+  # reproducibility. Each query was limited to 20 hits to not to overload the
+  # test suite.
 
   # BLASTP test scenarios
   it 'loads BLASTP XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.6.0/blastp')
 
-    # Click on the first hit Alignment download button on the page and wait for the download to finish.
+    # Click on the first hit Alignment download button on the page and wait for
+    # the download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -16,7 +19,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -26,7 +30,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -42,7 +47,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.6.0/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -56,7 +62,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -73,9 +80,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Circos download' do
     access_by_uuid('blast_2.6.0/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -93,7 +102,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('blast_2.6.0/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -115,7 +126,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.6.0/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -125,7 +137,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -134,7 +147,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
 
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
@@ -152,7 +166,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.6.0/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -165,7 +180,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
@@ -180,9 +196,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.6.0/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -198,7 +216,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.6.0/blastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -219,7 +239,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.6.0/blastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -228,7 +249,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -237,7 +259,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_5_checkbox')
     page.check('Query_1_hit_6_checkbox')
     page.check('Query_2_hit_5_checkbox')
@@ -253,7 +276,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.6.0/blastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -265,7 +289,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(2)').click()")
     wait_for_download
@@ -273,7 +298,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(2)').click()")
     wait_for_download
@@ -284,9 +310,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.6.0/blastn')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -302,7 +330,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.6.0/blastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -322,7 +352,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.6.0/tblastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -331,7 +362,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -340,7 +372,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_7_checkbox')
     page.check('Query_1_hit_8_checkbox')
     page.check('Query_2_hit_7_checkbox')
@@ -356,7 +389,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.6.0/tblastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
@@ -367,7 +401,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -375,7 +410,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -385,9 +421,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.6.0/tblastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -404,7 +442,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.6.0/tblastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -425,7 +465,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.6.0/tblastx')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(1)').click()")
     wait_for_download
@@ -434,7 +475,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -443,7 +485,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_9_checkbox')
     page.check('Query_1_hit_10_checkbox')
     page.check('Query_2_hit_9_checkbox')
@@ -459,7 +502,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.6.0/tblastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -471,7 +515,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -479,7 +524,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -490,9 +536,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.6.0/tblastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -509,7 +557,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.6.0/tblastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/blast_versions/blast_2.7.1/import_spec_capybara_local_2.7.1.rb
+++ b/spec/blast_versions/blast_2.7.1/import_spec_capybara_local_2.7.1.rb
@@ -1,12 +1,15 @@
 describe 'report generated from imported XML', type: :feature, js: true do
-  # Test suite to test features of imported XML report.
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility. Each query was limited to 20 hits to not to overload the test suite.
+  # Test suite to test features of imported XML report. Fasta files used for
+  # testing consist of TP53 and COX41 protein/nucleotide sequences for
+  # reproducibility. Each query was limited to 20 hits to not to overload the
+  # test suite.
 
   # BLASTP test scenarios
   it 'loads BLASTP XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.7.1/blastp')
 
-    # Click on the first hit Alignment download button on the page and wait for the download to finish.
+    # Click on the first hit Alignment download button on the page and wait for
+    # the download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -16,7 +19,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -26,7 +30,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -42,7 +47,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.7.1/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -56,7 +62,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -73,9 +80,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Circos download' do
     access_by_uuid('blast_2.7.1/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -93,7 +102,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('blast_2.7.1/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -115,7 +126,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.7.1/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -125,7 +137,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -134,7 +147,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
 
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
@@ -152,7 +166,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.7.1/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -165,7 +180,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
@@ -180,9 +196,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.7.1/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -198,7 +216,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.7.1/blastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -219,7 +239,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.7.1/blastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -228,7 +249,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -237,7 +259,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_5_checkbox')
     page.check('Query_1_hit_6_checkbox')
     page.check('Query_2_hit_5_checkbox')
@@ -253,7 +276,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.7.1/blastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -265,7 +289,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(2)').click()")
     wait_for_download
@@ -273,7 +298,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(2)').click()")
     wait_for_download
@@ -284,9 +310,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.7.1/blastn')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -302,7 +330,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.7.1/blastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -322,7 +352,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.7.1/tblastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -331,7 +362,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -340,7 +372,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_7_checkbox')
     page.check('Query_1_hit_8_checkbox')
     page.check('Query_2_hit_7_checkbox')
@@ -356,7 +389,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.7.1/tblastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
@@ -367,7 +401,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -375,7 +410,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -385,9 +421,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.7.1/tblastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -404,7 +442,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.7.1/tblastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -425,7 +465,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.7.1/tblastx')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(1)').click()")
     wait_for_download
@@ -434,7 +475,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -443,7 +485,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_9_checkbox')
     page.check('Query_1_hit_10_checkbox')
     page.check('Query_2_hit_9_checkbox')
@@ -459,7 +502,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.7.1/tblastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -471,7 +515,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -479,7 +524,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -490,9 +536,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.7.1/tblastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -509,7 +557,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.7.1/tblastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/blast_versions/blast_2.8.1/import_spec_capybara_local_2.8.1.rb
+++ b/spec/blast_versions/blast_2.8.1/import_spec_capybara_local_2.8.1.rb
@@ -1,12 +1,15 @@
 describe 'report generated from imported XML', type: :feature, js: true do
-  # Test suite to test features of imported XML report.
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility. Each query was limited to 20 hits to not to overload the test suite.
+  # Test suite to test features of imported XML report. Fasta files used for
+  # testing consist of TP53 and COX41 protein/nucleotide sequences for
+  # reproducibility. Each query was limited to 20 hits to not to overload the
+  # test suite.
 
   # BLASTP test scenarios
   it 'loads BLASTP XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.8.1/blastp')
 
-    # Click on the first hit Alignment download button on the page and wait for the download to finish.
+    # Click on the first hit Alignment download button on the page and wait for
+    # the download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -16,7 +19,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -26,7 +30,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -42,7 +47,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.8.1/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -56,7 +62,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -73,9 +80,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Circos download' do
     access_by_uuid('blast_2.8.1/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -93,7 +102,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('blast_2.8.1/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -115,7 +126,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.8.1/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -125,7 +137,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -134,7 +147,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
 
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
@@ -152,7 +166,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.8.1/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -165,7 +180,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
@@ -180,9 +196,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.8.1/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -198,7 +216,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.8.1/blastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -219,7 +239,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.8.1/blastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -228,7 +249,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -237,7 +259,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_5_checkbox')
     page.check('Query_1_hit_6_checkbox')
     page.check('Query_2_hit_5_checkbox')
@@ -253,7 +276,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.8.1/blastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -265,7 +289,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(2)').click()")
     wait_for_download
@@ -273,7 +298,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(2)').click()")
     wait_for_download
@@ -284,9 +310,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.8.1/blastn')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -302,7 +330,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.8.1/blastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -322,7 +352,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.8.1/tblastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -331,7 +362,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -340,7 +372,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_7_checkbox')
     page.check('Query_1_hit_8_checkbox')
     page.check('Query_2_hit_7_checkbox')
@@ -356,7 +389,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.8.1/tblastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
@@ -367,7 +401,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -375,7 +410,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -385,9 +421,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.8.1/tblastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -404,7 +442,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.8.1/tblastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -425,7 +465,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.8.1/tblastx')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(1)').click()")
     wait_for_download
@@ -434,7 +475,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -443,7 +485,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_9_checkbox')
     page.check('Query_1_hit_10_checkbox')
     page.check('Query_2_hit_9_checkbox')
@@ -459,7 +502,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads TBLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.8.1/tblastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -471,7 +515,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -479,7 +524,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -490,9 +536,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.8.1/tblastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -509,7 +557,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.8.1/tblastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/blast_versions/blast_2.9.0/import_spec_capybara_local_2.9.0.rb
+++ b/spec/blast_versions/blast_2.9.0/import_spec_capybara_local_2.9.0.rb
@@ -1,13 +1,16 @@
 describe 'report generated from imported XML',type: :feature, js: true do
 
-  # Test suite to test features of imported XML report.
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility. Each query was limited to 20 hits to not to overload the test suite.
+  # Test suite to test features of imported XML report. Fasta files used for
+  # testing consist of TP53 and COX41 protein/nucleotide sequences for
+  # reproducibility. Each query was limited to 20 hits to not to overload the
+  # test suite.
 
   # BLASTP test scenarios
   it 'loads BLASTP XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.9.0/blastp')
 
-    # Click on the first hit Alignment download button on the page and wait for the download to finish.
+    # Click on the first hit Alignment download button on the page and wait for
+    # the download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -16,7 +19,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -25,7 +29,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -41,7 +46,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
   it 'loads BLASTP XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('blast_2.9.0/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -55,7 +61,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -72,9 +79,11 @@ describe 'report generated from imported XML',type: :feature, js: true do
   it 'loads BLASTP XML and tests Circos download' do
     access_by_uuid('blast_2.9.0/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -92,7 +101,9 @@ describe 'report generated from imported XML',type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('blast_2.9.0/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -109,12 +120,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
 
-  #BLASTX test scenarios
+  # BLASTX test scenarios
 
   it 'loads BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.9.0/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -124,7 +136,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -133,7 +146,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
 
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
@@ -151,7 +165,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
   it 'loads BLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.9.0/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -164,7 +179,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
@@ -179,9 +195,11 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.9.0/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -197,7 +215,9 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
   it 'loads BLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.9.0/blastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -214,11 +234,12 @@ describe 'report generated from imported XML',type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
 
-  #BLASTN Test scenarios
+  # BLASTN Test scenarios
 
   it 'loads BLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.9.0/blastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -227,7 +248,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -236,7 +258,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_5_checkbox')
     page.check('Query_1_hit_6_checkbox')
     page.check('Query_2_hit_5_checkbox')
@@ -252,7 +275,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
   it 'loads BLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.9.0/blastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -264,7 +288,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(2)').click()")
     wait_for_download
@@ -272,7 +297,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(2)').click()")
     wait_for_download
@@ -283,9 +309,11 @@ describe 'report generated from imported XML',type: :feature, js: true do
   it 'loads BLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.9.0/blastn')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -301,7 +329,9 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
   it 'loads BLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.9.0/blastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -321,7 +351,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.9.0/tblastn')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
@@ -330,7 +361,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -339,7 +371,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_7_checkbox')
     page.check('Query_1_hit_8_checkbox')
     page.check('Query_2_hit_7_checkbox')
@@ -355,7 +388,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
   it 'loads TBLASTN XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.9.0/tblastn')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
@@ -366,7 +400,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -374,7 +409,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -384,9 +420,11 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Circos download' do
     access_by_uuid('blast_2.9.0/tblastn')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -403,7 +441,9 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
   it 'loads TBLASTN XML and tests Length distribution download' do
     access_by_uuid('blast_2.9.0/tblastn')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -424,7 +464,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('blast_2.9.0/tblastx')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
 
     page.execute_script("$('.download-aln:eq(1)').click()")
     wait_for_download
@@ -433,7 +474,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -442,7 +484,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_9_checkbox')
     page.check('Query_1_hit_10_checkbox')
     page.check('Query_2_hit_9_checkbox')
@@ -458,7 +501,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
   it 'loads TBLASTX XML and tests hit PNG/SVG download' do
     access_by_uuid('blast_2.9.0/tblastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -470,7 +514,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
@@ -478,7 +523,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the SVG download button of the first hit available and compare the downloaded content.
+    # Click on the SVG download button of the first hit available and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-svg:eq(1)').click()")
     wait_for_download
@@ -488,9 +534,11 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Circos download' do
     access_by_uuid('blast_2.9.0/tblastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -507,7 +555,9 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
   it 'loads TBLASTX XML and tests Length distribution download' do
     access_by_uuid('blast_2.9.0/tblastx')
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/blast_versions/diamond_0.9.24/import_spec_capybara_local_0.9.24.rb
+++ b/spec/blast_versions/diamond_0.9.24/import_spec_capybara_local_0.9.24.rb
@@ -1,8 +1,10 @@
 describe 'report generated from imported XML', type: :feature, js: true do
-  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide sequences for reproducibility.
+  # Fasta files used for testing consist of TP53 and COX41 protein/nucleotide
+  # sequences for reproducibility.
   it 'loads diamond BLASTP xml and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('diamond_0.9.24/blastp')
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_sp_P04637_P53_HUMAN.txt')
@@ -10,7 +12,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -19,7 +22,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/alignment-35_hits_diamond_blastp.txt'))
     clear_downloads
 
-    # Check the cheboxes of indicted hits and click on the download of Alignment of selected hits and compare the downloaded content
+    # Check the cheboxes of indicted hits and click on the download of Alignment
+    # of selected hits and compare the downloaded content
 
     page.check('Query_1_hit_1_checkbox')
     page.check('Query_1_hit_2_checkbox')
@@ -36,7 +40,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads diamond BLASTP XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('diamond_0.9.24/blastp')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
 
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
@@ -50,7 +55,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-sp_P04637_P53_HUMAN.png')
@@ -66,9 +72,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads diamond BLASTP XML and tests Circos download' do
     access_by_uuid('diamond_0.9.24/blastp')
 
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -86,7 +94,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads BLASTP XML and tests Length distribution download' do
     access_by_uuid('diamond_0.9.24/blastp')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")
@@ -108,7 +118,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads diamond BLASTX XML and tests hit alignment and sidebar Alignment download' do
     access_by_uuid('diamond_0.9.24/blastx')
 
-    # Click on the first Alignment download button on the page and wait for the download to finish.
+    # Click on the first Alignment download button on the page and wait for the
+    # download to finish.
     page.execute_script("$('.download-aln:eq(0)').click()")
     wait_for_download
 
@@ -117,7 +128,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     clear_downloads
 
-    # Click on the Alignment of all hits download and compare the downloaded content
+    # Click on the Alignment of all hits download and compare the downloaded
+    # content
 
     page.click_link('Alignment of all hits')
     wait_for_download
@@ -126,7 +138,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/alignment-35_hits_diamond_blastx.txt'))
     clear_downloads
 
-    # Select four hit checkboxes and click on the Alignment of selected hits. Compare the downloaded content.
+    # Select four hit checkboxes and click on the Alignment of selected hits.
+    # Compare the downloaded content.
     page.check('Query_1_hit_3_checkbox')
     page.check('Query_1_hit_4_checkbox')
     page.check('Query_2_hit_3_checkbox')
@@ -143,7 +156,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads diamond BLASTX XML and tests alignment overview and hit PNG/SVG download' do
     access_by_uuid('diamond_0.9.24/blastx')
 
-    # Click on the PNG/SVG download button of the alignment overview and compare the downloaded content.
+    # Click on the PNG/SVG download button of the alignment overview and compare
+    # the downloaded content.
     page.execute_script("$('.export-to-png:eq(0)').click()")
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
@@ -155,7 +169,8 @@ describe 'report generated from imported XML', type: :feature, js: true do
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
-    # Click on the PNG/SVG download button of the first hit available and compare the downloaded content.
+    # Click on the PNG/SVG download button of the first hit available and
+    # compare the downloaded content.
     page.execute_script("$('.export-to-png:eq(1)').click()")
 
     wait_for_download
@@ -171,9 +186,11 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
   it 'loads diamond BLASTX XML and tests Circos download' do
     access_by_uuid('diamond_0.9.24/blastx')
-    # Click on the Circos expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Circos expanding button, wait for animation, click on the
+    # download of PNG/SVG file and test that it initiated a file download in a
+    # right format.
 
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 
@@ -191,7 +208,9 @@ describe 'report generated from imported XML', type: :feature, js: true do
   it 'loads diamond BLASTX XML and tests Length distribution download' do
     access_by_uuid('diamond_0.9.24/blastx')
 
-    # Click on the Length distribution expanding button, wait for animation, click on the download of PNG/SVG file and test that it initiated a file download in a right format.
+    # Click on the Length distribution expanding button, wait for animation,
+    # click on the download of PNG/SVG file and test that it initiated a file
+    # download in a right format.
 
     page.should have_content('Length distribution of hits')
     page.execute_script("$('.length-distribution > .grapher-header > h5').click()")

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -231,7 +231,7 @@ describe 'a browser', type: :feature, js: true do
                    databases: protein_databases.values_at(0))
 
     ## Check that there is a circos vis and unfold it.
-    page.should have_content('Circos')
+    page.should have_content('Chord diagram: queries and their top hits')
     page.execute_script("$('.circos > .grapher-header > h5').click()")
     sleep 1
 


### PR DESCRIPTION
Since we changed the Circos visualisation title into a different one,
then the tests were failing as they were expecting the page to have
'Circos' content.

Additionally, I have cleaned up all the tests by wrapping up the
comments into a suitable length.

Signed-off-by: Iwo Pieniak <ivo.pieniak@gmail.com>