### PR TITLE
Updated check to enable Circos.

### DIFF
--- a/public/js/report.js
+++ b/public/js/report.js
@@ -259,7 +259,8 @@ var Report = React.createClass({
     },
 
     atLeastTwoHits: function () {
-        return this.state.queries.some(query => query.hits.length > 1);
+        var hit_num = (this.state.queries[this.state.queries.length - 1]).number;
+        return (this.state.queries.length >= 1 && hit_num > 1);
     },
 
     /**


### PR DESCRIPTION
It will be displayed if hit number is greater than 1 and if query number
is 1 or more.

Fix to the travis failing as previous solution did not allow to visualise case of 2 queries with one hit each.

Signed-off-by: Iwo Pieniak <ivo.pieniak@gmail.com>