### PR TITLE
Removal of hitless queries from Circos data

### DIFF
--- a/public/js/circos.js
+++ b/public/js/circos.js
@@ -24,7 +24,12 @@ class Graph {
     }
 
     constructor($svgContainer, props) {
-        this.queries = props.queries;
+        this.queries = [];
+        props.queries.forEach(query => {
+            if (query.hits.length > 0) {
+                this.queries.push(query);
+            }
+        });
         this.svgContainer = $svgContainer;
         this.seq_type = Helpers.get_seq_type(props.program);
         this.algorithm = props.program;


### PR DESCRIPTION
To avoid creating a circos vis that has hitless queries which affects
the overall look of the vis, a new array is created with only queries
that contain hits, which is later used to generate the vis.

Signed-off-by: Iwo Pieniak <ivo.pieniak@gmail.com>