### PR TITLE
Scan and update databases on page reload

### DIFF
--- a/lib/sequenceserver/blast/job.rb
+++ b/lib/sequenceserver/blast/job.rb
@@ -36,7 +36,7 @@ module SequenceServer
       def raise!
         return true if exitstatus == 0
 
-        stderr = File.readlines(this.stderr)
+        stderr = File.readlines(self.stderr)
         if exitstatus == 1 # error in query sequence or options; see [1]
           error = stderr.grep(ERROR_LINE)
           error = stderr if error.empty?

--- a/lib/sequenceserver/routes.rb
+++ b/lib/sequenceserver/routes.rb
@@ -56,6 +56,7 @@ module SequenceServer
 
     # Returns base HTML. Rest happens client-side: rendering the search form.
     get '/' do
+      Database.scan_databases_dir
       erb :search, layout: true
     end
 


### PR DESCRIPTION
Currently, when we add a new database, we must kill the server and start it again so the change shows up on the page. This means a downtime for the server. Here, I suggest adding a line to scan the databases on every page reload and eliminate the need to kill the sever.