### PR TITLE
Update routes.rb

### DIFF
--- a/lib/sequenceserver/routes.rb
+++ b/lib/sequenceserver/routes.rb
@@ -91,7 +91,7 @@ module SequenceServer
     post '/' do
       if params[:input_sequence]
         @input_sequence = params[:input_sequence]
-        erb :layout
+        erb :search, layout: true
       else
         job = Job.create(params)
         redirect to("/#{job.id}")


### PR DESCRIPTION
Switched `erb : layout` to `erb :search, layout: true` under `if params[:input_sequence]` so that (1) an error isn't thrown and (2) one gets a pre-filled sequence textarea if one posts the variable `input_sequence` from elsewhere. I believe this was a bug, since posting `input_sequence` generated an error. This solves issue #491 .