### PR TITLE
Handle incorrect BLAST+ or database dirs nicely

### DIFF
--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -184,8 +184,8 @@ begin
       # error scenarios either when creating a new SequenceServer (first
       # time or later), or updating config values using -s CLI option.
       rescue SequenceServer::BLAST_NOT_INSTALLED_OR_NOT_EXECUTABLE,
-             SequenceServer::BLAST_NOT_COMPATIBLE => e
-
+             SequenceServer::BLAST_NOT_COMPATIBLE,
+             SequenceServer::BLAST_BIN_DIR_NOT_FOUND => e
         # Show original error message first.
         puts
         puts e
@@ -254,8 +254,9 @@ begin
           puts
         end
         redo
-      rescue SequenceServer::DATABASE_DIR_NOT_SET => e
-        # Show original error message.
+      rescue SequenceServer::DATABASE_DIR_NOT_SET,
+             SequenceServer::DATABASE_DIR_NOT_FOUND => e
+        # Show original error message first.
         puts
         puts e
 

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -181,7 +181,7 @@ module SequenceServer
       if config[:bin]
         config[:bin] = File.expand_path config[:bin]
         unless File.exist?(config[:bin]) && File.directory?(config[:bin])
-          fail ENOENT.new('bin dir', config[:bin])
+          fail BLAST_BIN_DIR_NOT_FOUND
         end
         logger.debug("Will use NCBI BLAST+ at: #{config[:bin]}")
       else
@@ -198,7 +198,7 @@ module SequenceServer
       config[:database_dir] = File.expand_path(config[:database_dir])
       unless File.exist?(config[:database_dir]) &&
              File.directory?(config[:database_dir])
-        fail ENOENT.new('database dir', config[:database_dir])
+        fail DATABASE_DIR_NOT_FOUND
       end
 
       logger.debug("Will look for BLAST+ databases in: #{config[:database_dir]}")

--- a/lib/sequenceserver/exceptions.rb
+++ b/lib/sequenceserver/exceptions.rb
@@ -74,6 +74,15 @@ module SequenceServer
     end
   end
 
+  # Raised if there is no bin/ dir in the specified location.
+  class BLAST_BIN_DIR_NOT_FOUND < StandardError
+    def to_s
+      <<~MSG
+        Expected to find a bin/ directory but none existed at the path given.
+      MSG
+    end
+  end
+
   # Raised if SequenceServer determined NCBI BLAST+ present on the user's
   # system but not meeting SequenceServer's minimum version requirement.
   class BLAST_NOT_COMPATIBLE < StandardError
@@ -97,6 +106,13 @@ module SequenceServer
   class DATABASE_DIR_NOT_SET < StandardError
     def to_s
       'Database dir not set.'
+    end
+  end
+
+  # Raised if database_dir doesn't exist or isn't a directory.
+  class DATABASE_DIR_NOT_FOUND < StandardError
+    def to_s
+      "Database directory provided doesn't exist (or isn't a directory)."
     end
   end
 

--- a/spec/sequenceserver_spec.rb
+++ b/spec/sequenceserver_spec.rb
@@ -15,12 +15,12 @@ module SequenceServer
       # Raise if bin dir is not a directory.
       expect do
         SequenceServer.init(bin: __FILE__)
-      end.to raise_error(ENOENT)
+      end.to raise_error(BLAST_BIN_DIR_NOT_FOUND)
 
       # Raise if bin dir does not exist.
       expect do
         SequenceServer.init(bin: '/foo/bar')
-      end.to raise_error(ENOENT)
+      end.to raise_error(BLAST_BIN_DIR_NOT_FOUND)
     end
 
     # database_dir is compulsory
@@ -35,12 +35,12 @@ module SequenceServer
       # Raise if database_dir is not a directory.
       expect do
         SequenceServer.init(database_dir: __FILE__)
-      end.to raise_error(ENOENT)
+      end.to raise_error(DATABASE_DIR_NOT_FOUND)
 
       # Raise if database_dir does not exist.
       expect do
         SequenceServer.init(database_dir: '/foo/bar')
-      end.to raise_error(ENOENT)
+      end.to raise_error(DATABASE_DIR_NOT_FOUND)
     end
 
     # database_dir, when correctly set, should contain at least one BLAST+


### PR DESCRIPTION
- If a user provides incorrect directory paths during setup, ask them repeatedly for the correct ones (instead of exiting)

As mentioned in issue #456, sequenceserver exits immediately if an incorrect BLAST+ directory or database directory is given.  By raising a couple of new exceptions and catching them (as is already done for incompatible BLAST versions) we let the user try again.