### PR TITLE
Fix docker build error when using BuildKit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY . .
 # Generate config file with default configs and database directory set to /db.
 # Setting database directory in config file means users can pass command line
 # arguments to SequenceServer without having to specify -d option again.
-RUN echo 'n' | bundle exec bin/sequenceserver -s -d /db
+RUN mkdir -p /db && echo 'n' | script -qfec "bundle exec bin/sequenceserver -s -d /db" /dev/null 
 
 # Prevent SequenceServer from prompting user to join announcements list.
 RUN mkdir -p ~/.sequenceserver && touch ~/.sequenceserver/asked_to_join


### PR DESCRIPTION
Fixes #502 

BuildKit apparently doesn't create directories associated with VOLUMEs at build time, so the `mkdir -p /db` is necessary here as well.