### PR TITLE
Ensure customizations to CSS & JavaScript are reflected in container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !bin
 !config.ru
 !lib
+!package.json
 !public
 !sequenceserver.gemspec
 !views

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,18 @@
 # for the variables to be accessible in FROM instruction.
 ARG BLAST_VERSION=2.10.0
 
-## Stage 1: gem dependencies.
+## Stage 1: CSS & JS.
+FROM node:15-alpine3.12 AS node
+
+RUN apk add --no-cache git
+WORKDIR /usr/src/app
+COPY ./package.json .
+RUN npm install
+ENV PATH=${PWD}/node_modules/.bin:${PATH}
+COPY public public
+RUN npm run-script build
+
+## Stage 2: gem dependencies.
 FROM ruby:2.7-slim-buster AS builder
 
 # Copy over files required for installing gem dependencies.
@@ -18,12 +29,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN bundle install --without=development
 
 
-## Stage 2: BLAST+ binaries.
+## Stage 3: BLAST+ binaries.
 # We will copy them from NCBI's docker image.
 FROM ncbi/blast:${BLAST_VERSION} AS ncbi-blast
 
 
-## Stage 3: Puting it together.
+## Stage 4: Puting it together.
 FROM ruby:2.7-slim-buster
 
 LABEL Description="Intuitive local web frontend for the BLAST bioinformatics tool"
@@ -55,6 +66,9 @@ WORKDIR /sequenceserver
 VOLUME ["/db"]
 EXPOSE 4567
 COPY . .
+
+COPY --from=node /usr/src/app/public/sequenceserver-*.min.js public/
+COPY --from=node /usr/src/app/public/css/sequenceserver.min.css public/css/
 
 # Generate config file with default configs and database directory set to /db.
 # Setting database directory in config file means users can pass command line


### PR DESCRIPTION
Currently, updates to public/css & public/js aren't reflected in the minified versions used in the Docker image. It would be convenient if the Dockerfile took care of generating these. I'm not familiar with best practices for jspm in Dockerfiles, but this naive attempt seemed to work, and could be at least a starting point to refine.

Alternatively, as it looks like jspm was [deprecated in June 2020](https://github.com/jspm/jspm-cli), and it's probably worth investigating a replacement.