### PR TITLE
Fixed sidebar overflow for long seqids. Fixes #571 and #570.

### DIFF
--- a/public/css/sequenceserver.css
+++ b/public/css/sequenceserver.css
@@ -447,6 +447,12 @@ input[type=checkbox] {
   padding: 3px 2px;
 }
 
+.sidebar .nowrap-ellipsis {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .sidebar.affix {
   margin-top: 0;
   top: 0;


### PR DESCRIPTION
Using as a guide the mention of `nowrap-ellipsis` on line 148, `sidebar.js`, I forced this to all queries in the sidebar.

Tested it works on Firefox and Chromium.
This is how it looks like: 
![image](https://user-images.githubusercontent.com/10999402/148553961-f5f11316-736a-465b-abb4-852aa2dc7df0.png)

Tooltip shows up as expected.
![hoveronmouseSequenceServer](https://user-images.githubusercontent.com/10999402/148569414-83f03917-da87-4583-8345-e50c9c5a2b5a.jpg)

