### PR TITLE
Fixes the security issue from #569

### DIFF
--- a/lib/sequenceserver/sys.rb
+++ b/lib/sequenceserver/sys.rb
@@ -47,8 +47,8 @@ module SequenceServer
 
       # Execute the shell command, redirect stdout and stderr to the
       # temporary files.
-      exec("#{command} 1>#{temp_files[:stdout].path}" \
-           " 2>#{temp_files[:stderr].path}")
+      exec(command, out: temp_files[:stdout].path.to_s, \
+                    err: temp_files[:stderr].path.to_s)
     end
 
     # Wait for the termination of the child process.


### PR DESCRIPTION
exec function now does not invoke shell with user's parameters at all
I used (exec(command, args, ...)