### PR TITLE
Rubocop no longer supports ruby version 2.3

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,6 +10,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
+    channel: rubocop-1-23-0
   eslint:
     enabled: true
   stylelint:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.6
   Exclude:
     # Because these are vendor files.
     - 'node_modules/**/*'


### PR DESCRIPTION
I was checking rubocop and found this:
`
Error: RuboCop found unsupported Ruby version 2.3 in `TargetRubyVersion` parameter (in .rubocop.yml). 2.3-compatible analysis was dropped after version 0.81.
Supported versions: 2.5, 2.6, 2.7, 3.0, 3.1, 3.2
`

I changed it to 2.6 for now, later we should update it to 3.2