### PR TITLE
Fix the one failing capybara test when run locally

### DIFF
--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -36,7 +36,7 @@ describe 'a browser', type: :feature, js: true do
     visit '/'
     fill_in('sequence', with: nucleotide_query)
     check(nucleotide_databases.first)
-    page.has_css?('button.dropdown-toggle').should eq(true)
+    page.has_css?('#methods button.dropdown-toggle').should eq(true)
   end
 
   it 'can run a simple blastn search' do
@@ -325,8 +325,8 @@ describe 'a browser', type: :feature, js: true do
     fill_in('sequence', with: query)
     databases.each { |db| check db }
     if method == 'tblastx'
-      find('.dropdown-toggle').click
-      find('.dropdown-menu li').click
+      find('#methods .dropdown-toggle').click
+      find('#methods .dropdown-menu li').click
     end
     click_button('method')
 


### PR DESCRIPTION
I had one failing capybara test when run locally:

```
Failure/Error: find('.dropdown-toggle').click

     Capybara::Ambiguous:
       Ambiguous match, found 2 elements matching visible css ".dropdown-toggle"
```

(had also come up in https://github.com/wurmlab/sequenceserver/issues/556#issuecomment-1116180507)

This was due to the introduction of an additional .dropdown-toggle
element on the search page in 2181d290 for the presets feature.