### PR TITLE
Clear SequenceServer::Database.collection after each test context

### DIFF
--- a/spec/download_helper.rb
+++ b/spec/download_helper.rb
@@ -14,7 +14,8 @@ module DownloadHelpers
   end
 
   def downloaded_file
-    downloads.first
+    warn "*** Multiple files in downloads directory. Expected one. ***" if downloads.length > 1
+    downloads.sort_by { |f| File.mtime(f) }.last
   end
 
   def clear_downloads

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,4 +60,8 @@ RSpec.configure do |config|
   config.after :context, type: :feature do
     FileUtils.rm_rf Dir[SequenceServer::DOTDIR + '/*-*-*-*-*']
   end
+
+  config.after :context do
+    SequenceServer::Database.clear
+  end
 end


### PR DESCRIPTION
Test suites may initialise SequenceServer using different databases
directories in spec/. Many of the databases in the different subdirs are
essentially the same (same content, same display name), just formatted a
little different: v4, v5, with or without -parse_seqids option. This can
result in an accumulation of databases with the same name in the process
and cause confusion. For example, Capybara test that require selecting a
database in the interface based on name may fail because of ambiguous
matches.

Automatically clearing SequenceServer::Database.collection fixes this
problem.

/cc @iQuxLE 