### PR TITLE
Use full image for builder stage; update to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG BLAST_VERSION=2.14.0
 
 ## Stage 1: gem dependencies.
-FROM ruby:3.2.0-slim-buster AS builder
+FROM ruby:3.2.2-bullseye AS builder
 
 # Copy over files required for installing gem dependencies.
 WORKDIR /sequenceserver
@@ -22,7 +22,7 @@ RUN bundle install --without=development
 FROM ncbi/blast:${BLAST_VERSION} AS ncbi-blast
 
 ## Stage 3: Puting it together.
-FROM ruby:3.2.0-slim-buster AS final
+FROM ruby:3.2.2-bullseye AS final
 
 LABEL Description="Intuitive local web frontend for the BLAST bioinformatics tool"
 LABEL MailingList="https://groups.google.com/forum/#!forum/sequenceserver"
@@ -88,7 +88,7 @@ COPY --from=node /usr/src/app/public/sequenceserver-*.min.js public/
 COPY --from=node /usr/src/app/public/css/sequenceserver.min.css public/css/
 
 ## Stage 6 (optional) Pull the example database from the debian package.
-FROM ruby:3.2.0-slim-buster AS example_db
+FROM ruby:3.2.2-bullseye AS example_db
 
 WORKDIR /tmp
 RUN apt-get update && apt-get download ncbi-blast+ && dpkg-deb -xv ncbi-blast+*.deb .


### PR DESCRIPTION
Address issue #673 by using a full (rather than slim) image for the builder stage. An alternative would be adding `g++` to the list of installed packages: 

https://github.com/wurmlab/sequenceserver/blob/ae0765933859b2ac692c52388a99126ab39f9712/Dockerfile#L13-L15

However, using the full base image (which contains Debian packages needed to build ruby extensions, obviating the need to explicitly install such packages via the Dockerfile) seems less likely to fail in the future due to missing Debian packages dependencies that extensions may have.

It's also probably worth updating from buster to bullseye, as support for new Docker official ruby buster images [was dropped](https://github.com/docker-library/ruby/commit/ed1be47a38a7a24a0aa03c450549afcb592f02a8) after bookworm was available (it might be preferable to delay updating to bookworm in case any users still run an old Docker < 2.10.10, which has difficulty building images with glibc >= 2.34 due to [this issue](https://github.com/actions/runner-images/issues/4193)). 