### PR TITLE
Fix thread shutdown logic

### DIFF
--- a/lib/sequenceserver/pool.rb
+++ b/lib/sequenceserver/pool.rb
@@ -42,7 +42,7 @@ class Pool
 
   def shutdown
     @size.times do
-      schedule { throw :exit }
+      queue { throw :exit }
     end
     @pool.map(&:join)
   end


### PR DESCRIPTION
Shutdown was calling a non-existant 'schedule' method. Seems like the original thread pool's schedule method was renamed to 'queue' here, but this reference was not updated.