### PR TITLE
Add .faa as a recognised fasta extension

### DIFF
--- a/lib/sequenceserver/blast/report.rb
+++ b/lib/sequenceserver/blast/report.rb
@@ -51,6 +51,8 @@ module SequenceServer
       end
 
       def xml_file_size
+        return File.size(job.imported_xml_file) if job.imported_xml_file
+
         generate
 
         xml_formatter.size
@@ -86,6 +88,8 @@ module SequenceServer
       end
 
       def done?
+        return true if job.imported_xml_file
+
         File.exist?(xml_formatter.filepath) && File.exist?(tsv_formatter.filepath)
       end
 

--- a/lib/sequenceserver/makeblastdb.rb
+++ b/lib/sequenceserver/makeblastdb.rb
@@ -289,7 +289,9 @@ module SequenceServer
 
     # Returns true if first character of the file is '>'.
     def probably_fasta?(file)
-      return false unless file.match(/((cds)|(fasta)|(fna)|(pep)|(cdna)|(fa)|(prot)|(fas)|(genome)|(nuc)|(dna)|(nt))$/i)
+      unless file.match(/((cdna)|(cds)|(dna)|(fa)|(faa)|(fas)|(fasta)|(fna)|(genome)|(nt)|(nuc)|(pep)|(prot))$/i)
+        return false
+      end
 
       File.read(file, 1) == '>'
     end

--- a/spec/blast_versions/blast_2.2.30/import_spec_capybara_local_2.2.30.rb
+++ b/spec/blast_versions/blast_2.2.30/import_spec_capybara_local_2.2.30.rb
@@ -12,7 +12,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first hit Alignment download button on the page and wait for
     # the download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_120407068_ref_NP_000537_3.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/sp_P04637_P53_HUMAN_gi_120407068_ref_NP_000537_3.txt'))
@@ -49,13 +49,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -63,13 +63,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_120407068_ref_NP_000537_3.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_120407068_ref_NP_000537_3.svg')
     page.should have_content('BLASTP')
@@ -85,12 +85,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -105,13 +105,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -123,7 +123,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/MH011443_1_gi_1486783307_gb_AYF55702_1.txt'))
@@ -160,13 +160,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -174,13 +174,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.svg')
     page.should have_content('BLASTX')
@@ -196,12 +196,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -216,13 +216,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -235,7 +235,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783306_gb_MH011443_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/MH011443_1_gi_1486783306_gb_MH011443_1.txt'))
@@ -271,13 +271,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -285,7 +285,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(2)').click()")
+    page.find_all(".export-to-png")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.png')
 
@@ -294,7 +294,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(2)').click()")
+    page.find_all(".export-to-svg")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.svg')
     page.should have_content('BLASTN')
@@ -310,12 +310,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -330,12 +330,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -348,7 +348,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_1484127324_gb_MG595988_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/sp_P04637_P53_HUMAN_gi_1484127324_gb_MG595988_1.txt'))
@@ -385,13 +385,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -400,7 +400,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1484127324_gb_MG595988_1.png')
 
@@ -409,7 +409,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1484127324_gb_MG595988_1.svg')
     page.should have_content('TBLASTN')
@@ -425,13 +425,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -446,13 +446,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -464,7 +464,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(1)').click()")
+    page.find_all(".download-aln")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1528997474_gb_MH447967_1.txt')
     expect(File.read(downloaded_file)). to eq(File.read('spec/sequences/MH011443_1_gi_1528997474_gb_MH447967_1.txt'))
@@ -500,13 +500,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -515,7 +515,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.png')
 
@@ -524,7 +524,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.svg')
     page.should have_content('TBLASTX')
@@ -540,13 +540,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -561,13 +561,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end

--- a/spec/blast_versions/blast_2.2.31/import_spec_capybara_local_2.2.31.rb
+++ b/spec/blast_versions/blast_2.2.31/import_spec_capybara_local_2.2.31.rb
@@ -11,7 +11,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first hit Alignment download button on the page and wait for
     # the download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_1099170394_ref_XP_018868681_1.txt')
@@ -50,13 +50,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -65,13 +65,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.svg')
     page.should have_content('BLASTP')
@@ -88,13 +88,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -110,13 +110,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -129,7 +129,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
@@ -168,13 +168,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -182,13 +182,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.svg')
     page.should have_content('BLASTX')
@@ -204,12 +204,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -224,13 +224,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -242,7 +242,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783306_gb_MH011443_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/MH011443_1_gi_1486783306_gb_MH011443_1.txt'))
@@ -278,13 +278,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -292,7 +292,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(2)').click()")
+    page.find_all(".export-to-png")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.png')
 
@@ -301,7 +301,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(2)').click()")
+    page.find_all(".export-to-svg")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.svg')
     page.should have_content('BLASTN')
@@ -318,12 +318,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -338,12 +338,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -355,7 +355,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt'))
@@ -391,20 +391,20 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.png')
 
@@ -413,7 +413,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.svg')
     page.should have_content('TBLASTN')
@@ -429,13 +429,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -450,13 +450,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -468,7 +468,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(1)').click()")
+    page.find_all(".download-aln")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1528997474_gb_MH447967_1.txt')
     expect(File.read(downloaded_file)). to eq(File.read('spec/sequences/MH011443_1_gi_1528997474_gb_MH447967_1.txt'))
@@ -504,13 +504,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -518,7 +518,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.png')
 
@@ -527,7 +527,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.svg')
 
@@ -544,13 +544,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -565,13 +565,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end

--- a/spec/blast_versions/blast_2.3.0/import_spec_capybara_local_2.3.0.rb
+++ b/spec/blast_versions/blast_2.3.0/import_spec_capybara_local_2.3.0.rb
@@ -11,7 +11,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first hit Alignment download button on the page and wait for
     # the download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_1099170394_ref_XP_018868681_1.txt')
@@ -50,13 +50,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -65,13 +65,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.svg')
     page.should have_content('BLASTP')
@@ -88,13 +88,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -110,13 +110,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -129,7 +129,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
@@ -168,13 +168,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -182,13 +182,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.svg')
     page.should have_content('BLASTX')
@@ -204,12 +204,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -224,13 +224,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -242,7 +242,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783306_gb_MH011443_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/MH011443_1_gi_1486783306_gb_MH011443_1.txt'))
@@ -278,13 +278,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -292,7 +292,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(2)').click()")
+    page.find_all(".export-to-png")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.png')
 
@@ -301,7 +301,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(2)').click()")
+    page.find_all(".export-to-svg")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.svg')
     page.should have_content('BLASTN')
@@ -318,12 +318,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -338,12 +338,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -355,7 +355,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt'))
@@ -391,20 +391,20 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.png')
 
@@ -413,7 +413,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.svg')
     page.should have_content('TBLASTN')
@@ -429,13 +429,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -450,13 +450,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -468,7 +468,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(1)').click()")
+    page.find_all(".download-aln")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1528997474_gb_MH447967_1.txt')
     expect(File.read(downloaded_file)). to eq(File.read('spec/sequences/MH011443_1_gi_1528997474_gb_MH447967_1.txt'))
@@ -504,13 +504,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -518,7 +518,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.png')
 
@@ -527,7 +527,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.svg')
 
@@ -544,13 +544,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -565,13 +565,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end

--- a/spec/blast_versions/blast_2.4.0/import_spec_capybara_local_2.4.0.rb
+++ b/spec/blast_versions/blast_2.4.0/import_spec_capybara_local_2.4.0.rb
@@ -10,7 +10,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first hit Alignment download button on the page and wait for
     # the download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_1099170394_ref_XP_018868681_1.txt')
@@ -48,13 +48,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -62,13 +62,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.svg')
@@ -85,12 +85,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -105,12 +105,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -122,7 +122,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
@@ -160,26 +160,26 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
 
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.svg')
@@ -196,12 +196,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -216,13 +216,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -234,7 +234,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783306_gb_MH011443_1.txt')
@@ -272,13 +272,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -286,7 +286,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(2)').click()")
+    page.find_all(".export-to-png")[2].click
 
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.png')
@@ -296,7 +296,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(2)').click()")
+    page.find_all(".export-to-svg")[2].click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.svg')
@@ -313,12 +313,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -332,12 +332,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.should have_content('Length distribution of matching sequences')
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -349,7 +349,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt')
@@ -387,13 +387,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -401,7 +401,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
 
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.png')
@@ -410,7 +410,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.svg')
@@ -427,13 +427,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -448,13 +448,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -466,7 +466,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(1)').click()")
+    page.find_all(".download-aln")[1].click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1528997474_gb_MH447967_1.txt')
@@ -504,13 +504,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -518,7 +518,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
 
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.png')
@@ -528,7 +528,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.svg')
@@ -545,13 +545,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -566,13 +566,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end

--- a/spec/blast_versions/blast_2.5.0/import_spec_capybara_local_2.5.0.rb
+++ b/spec/blast_versions/blast_2.5.0/import_spec_capybara_local_2.5.0.rb
@@ -11,7 +11,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first hit Alignment download button on the page and wait for
     # the download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_1099170394_ref_XP_018868681_1.txt')
@@ -50,13 +50,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -65,13 +65,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.svg')
     page.should have_content('BLASTP')
@@ -88,13 +88,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -110,13 +110,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -129,7 +129,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
@@ -168,13 +168,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -182,13 +182,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.svg')
     page.should have_content('BLASTX')
@@ -204,12 +204,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -224,13 +224,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -242,7 +242,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783306_gb_MH011443_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/MH011443_1_gi_1486783306_gb_MH011443_1.txt'))
@@ -278,13 +278,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -292,7 +292,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(2)').click()")
+    page.find_all(".export-to-png")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.png')
 
@@ -301,7 +301,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(2)').click()")
+    page.find_all(".export-to-svg")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.svg')
     page.should have_content('BLASTN')
@@ -318,12 +318,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -338,12 +338,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -355,7 +355,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt'))
@@ -391,20 +391,20 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.png')
 
@@ -413,7 +413,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.svg')
     page.should have_content('TBLASTN')
@@ -429,13 +429,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -450,13 +450,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -468,7 +468,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(1)').click()")
+    page.find_all(".download-aln")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1528997474_gb_MH447967_1.txt')
     expect(File.read(downloaded_file)). to eq(File.read('spec/sequences/MH011443_1_gi_1528997474_gb_MH447967_1.txt'))
@@ -504,13 +504,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -518,7 +518,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.png')
 
@@ -527,7 +527,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.svg')
 
@@ -544,13 +544,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -565,13 +565,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end

--- a/spec/blast_versions/blast_2.6.0/import_spec_capybara_local_2.6.0.rb
+++ b/spec/blast_versions/blast_2.6.0/import_spec_capybara_local_2.6.0.rb
@@ -11,7 +11,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first hit Alignment download button on the page and wait for
     # the download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_1099170394_ref_XP_018868681_1.txt')
@@ -50,13 +50,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -65,13 +65,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.svg')
     page.should have_content('BLASTP')
@@ -88,13 +88,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -110,13 +110,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -129,7 +129,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
@@ -168,13 +168,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -182,13 +182,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.svg')
     page.should have_content('BLASTX')
@@ -204,12 +204,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -224,13 +224,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -242,7 +242,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783306_gb_MH011443_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/MH011443_1_gi_1486783306_gb_MH011443_1.txt'))
@@ -278,13 +278,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -292,7 +292,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(2)').click()")
+    page.find_all(".export-to-png")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.png')
 
@@ -301,7 +301,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(2)').click()")
+    page.find_all(".export-to-svg")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.svg')
     page.should have_content('BLASTN')
@@ -318,12 +318,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -338,12 +338,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -355,7 +355,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt'))
@@ -391,20 +391,20 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.png')
 
@@ -413,7 +413,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.svg')
     page.should have_content('TBLASTN')
@@ -429,13 +429,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -450,13 +450,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -468,7 +468,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(1)').click()")
+    page.find_all(".download-aln")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1528997474_gb_MH447967_1.txt')
     expect(File.read(downloaded_file)). to eq(File.read('spec/sequences/MH011443_1_gi_1528997474_gb_MH447967_1.txt'))
@@ -504,13 +504,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -518,7 +518,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.png')
 
@@ -527,7 +527,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.svg')
 
@@ -544,13 +544,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -565,13 +565,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end

--- a/spec/blast_versions/blast_2.7.1/import_spec_capybara_local_2.7.1.rb
+++ b/spec/blast_versions/blast_2.7.1/import_spec_capybara_local_2.7.1.rb
@@ -11,7 +11,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first hit Alignment download button on the page and wait for
     # the download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_1099170394_ref_XP_018868681_1.txt')
@@ -50,13 +50,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -65,13 +65,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.svg')
     page.should have_content('BLASTP')
@@ -88,13 +88,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -110,13 +110,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -129,7 +129,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
@@ -168,13 +168,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -182,13 +182,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.svg')
     page.should have_content('BLASTX')
@@ -204,12 +204,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -224,13 +224,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -242,7 +242,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783306_gb_MH011443_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/MH011443_1_gi_1486783306_gb_MH011443_1.txt'))
@@ -278,13 +278,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -292,7 +292,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(2)').click()")
+    page.find_all(".export-to-png")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.png')
 
@@ -301,7 +301,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(2)').click()")
+    page.find_all(".export-to-svg")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.svg')
     page.should have_content('BLASTN')
@@ -318,12 +318,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -338,12 +338,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -355,7 +355,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt'))
@@ -391,20 +391,20 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.png')
 
@@ -413,7 +413,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.svg')
     page.should have_content('TBLASTN')
@@ -429,13 +429,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -450,13 +450,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -468,7 +468,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(1)').click()")
+    page.find_all(".download-aln")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1528997474_gb_MH447967_1.txt')
     expect(File.read(downloaded_file)). to eq(File.read('spec/sequences/MH011443_1_gi_1528997474_gb_MH447967_1.txt'))
@@ -504,13 +504,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -518,7 +518,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.png')
 
@@ -527,7 +527,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.svg')
 
@@ -544,13 +544,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -565,13 +565,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end

--- a/spec/blast_versions/blast_2.8.1/import_spec_capybara_local_2.8.1.rb
+++ b/spec/blast_versions/blast_2.8.1/import_spec_capybara_local_2.8.1.rb
@@ -11,7 +11,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first hit Alignment download button on the page and wait for
     # the download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_1099170394_ref_XP_018868681_1.txt')
@@ -50,13 +50,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -65,13 +65,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.svg')
     page.should have_content('BLASTP')
@@ -88,13 +88,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -110,13 +110,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -129,7 +129,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
@@ -168,13 +168,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -182,13 +182,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.svg')
     page.should have_content('BLASTX')
@@ -204,12 +204,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -224,13 +224,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -242,7 +242,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783306_gb_MH011443_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/MH011443_1_gi_1486783306_gb_MH011443_1.txt'))
@@ -278,13 +278,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -292,7 +292,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(2)').click()")
+    page.find_all(".export-to-png")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.png')
 
@@ -301,7 +301,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(2)').click()")
+    page.find_all(".export-to-svg")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.svg')
     page.should have_content('BLASTN')
@@ -318,12 +318,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -338,12 +338,12 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -355,7 +355,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt'))
@@ -391,20 +391,20 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.png')
 
@@ -413,7 +413,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.svg')
     page.should have_content('TBLASTN')
@@ -429,13 +429,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -450,13 +450,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -468,7 +468,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(1)').click()")
+    page.find_all(".download-aln")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1528997474_gb_MH447967_1.txt')
     expect(File.read(downloaded_file)). to eq(File.read('spec/sequences/MH011443_1_gi_1528997474_gb_MH447967_1.txt'))
@@ -504,13 +504,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -518,7 +518,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.png')
 
@@ -527,7 +527,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.svg')
 
@@ -544,13 +544,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -565,13 +565,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end

--- a/spec/blast_versions/blast_2.9.0/import_spec_capybara_local_2.9.0.rb
+++ b/spec/blast_versions/blast_2.9.0/import_spec_capybara_local_2.9.0.rb
@@ -1,5 +1,8 @@
+require 'spec_helper'
+
 describe 'report generated from imported XML',type: :feature, js: true do
 
+  before(:all) { SequenceServer.init }
   # Test suite to test features of imported XML report. Fasta files used for
   # testing consist of TP53 and COX41 protein/nucleotide sequences for
   # reproducibility. Each query was limited to 20 hits to not to overload the
@@ -12,7 +15,7 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the first hit Alignment download button on the page and wait for
     # the download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_1099170394_ref_XP_018868681_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read("spec/sequences/sp_P04637_P53_HUMAN_gi_1099170394_ref_XP_018868681_1.txt"))
@@ -49,13 +52,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -64,13 +67,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_1099170394_ref_XP_018868681_1.svg')
     page.should have_content('BLASTP')
@@ -87,13 +90,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -109,13 +112,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -128,7 +131,7 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783307_gb_AYF55702_1.txt')
@@ -167,13 +170,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -181,13 +184,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783307_gb_AYF55702_1.svg')
     page.should have_content('BLASTX')
@@ -203,12 +206,12 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -223,13 +226,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -241,7 +244,7 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1486783306_gb_MH011443_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read("spec/sequences/MH011443_1_gi_1486783306_gb_MH011443_1.txt"))
@@ -277,13 +280,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -291,7 +294,7 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(2)').click()")
+    page.find_all(".export-to-png")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.png')
 
@@ -300,7 +303,7 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(2)').click()")
+    page.find_all(".export-to-svg")[2].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1528997474_gb_MH447967_1.svg')
     page.should have_content('BLASTN')
@@ -317,12 +320,12 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -337,12 +340,12 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end
@@ -354,7 +357,7 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt')
     expect(File.read(downloaded_file)).to eq(File.read("spec/sequences/sp_P04637_P53_HUMAN_gi_395440626_gb_JQ694049_1.txt"))
@@ -390,20 +393,20 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
     clear_downloads
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.png')
 
@@ -412,7 +415,7 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-gi_395440626_gb_JQ694049_1.svg')
     page.should have_content('TBLASTN')
@@ -428,13 +431,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -449,13 +452,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -467,7 +470,8 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
 
-    page.execute_script("$('.download-aln:eq(1)').click()")
+    expect(page).to have_selector('.download-aln', minimum: 30) # Wait for react to render all alignments
+    page.find_all(".download-aln")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('MH011443_1_gi_1528997474_gb_MH447967_1.txt')
     expect(File.read(downloaded_file)). to eq(File.read("spec/sequences/MH011443_1_gi_1528997474_gb_MH447967_1.txt"))
@@ -503,13 +507,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
@@ -517,7 +521,7 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the PNG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.png')
 
@@ -526,7 +530,7 @@ describe 'report generated from imported XML',type: :feature, js: true do
     # Click on the SVG download button of the first hit available and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-gi_1486783306_gb_MH011443_1.svg')
     page.should have_content('TBLASTX')
@@ -542,13 +546,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -563,13 +567,13 @@ describe 'report generated from imported XML',type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end

--- a/spec/blast_versions/diamond_0.9.24/import_spec_capybara_local_0.9.24.rb
+++ b/spec/blast_versions/diamond_0.9.24/import_spec_capybara_local_0.9.24.rb
@@ -5,7 +5,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
     access_by_uuid('diamond_0.9.24/blastp')
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('sp_P04637_P53_HUMAN_sp_P04637_P53_HUMAN.txt')
     expect(File.read(downloaded_file)).to eq(File.read('spec/sequences/sp_P04637_P53_HUMAN_sp_P04637_P53_HUMAN.txt'))
@@ -43,13 +43,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-sp_P04637_P53_HUMAN.svg')
 
@@ -57,13 +57,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-sp_P04637_P53_HUMAN-sp_P04637_P53_HUMAN.svg')
     page.should have_content('BLASTP')
@@ -80,13 +80,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -102,13 +102,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-sp_P04637_P53_HUMAN.svg')
   end
@@ -120,7 +120,7 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the first Alignment download button on the page and wait for the
     # download to finish.
-    page.execute_script("$('.download-aln:eq(0)').click()")
+    page.first('.download-aln').click
     wait_for_download
 
     expect(File.basename(downloaded_file)).to eq('MH011443_1_sp_P04637_P53_HUMAN.txt')
@@ -158,27 +158,27 @@ describe 'report generated from imported XML', type: :feature, js: true do
 
     # Click on the PNG/SVG download button of the alignment overview and compare
     # the downloaded content.
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Alignment-Overview-MH011443_1.svg')
 
     clear_downloads
     # Click on the PNG/SVG download button of the first hit available and
     # compare the downloaded content.
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
 
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-sp_P04637_P53_HUMAN.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Kablammo-MH011443_1-sp_P04637_P53_HUMAN.svg')
     page.should have_content('BLASTX')
@@ -194,13 +194,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.circos > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(0)').click()")
+    page.first('.export-to-png').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(0)').click()")
+    page.first('.export-to-svg').click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('Circos-visualisation.svg')
   end
@@ -216,13 +216,13 @@ describe 'report generated from imported XML', type: :feature, js: true do
     page.execute_script("$('.length-distribution > .grapher-header > h4').click()")
     sleep 1
 
-    page.execute_script("$('.export-to-png:eq(1)').click()")
+    page.find_all(".export-to-png")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.png')
 
     clear_downloads
 
-    page.execute_script("$('.export-to-svg:eq(1)').click()")
+    page.find_all(".export-to-svg")[1].click
     wait_for_download
     expect(File.basename(downloaded_file)).to eq('length-distribution-MH011443_1.svg')
   end


### PR DESCRIPTION
It was missing from the list (its nucleotide counterpart `.fna` is in here already). 

Also order the list alphabetically.