### PR TITLE
[Performance] Do not perform unnecessary operations in makeblastdb

### DIFF
--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -296,7 +296,7 @@ begin
           unless response =~ /^[n]$/i
             puts
             puts 'Searching ...'
-            if SequenceServer.makeblastdb.any_unformatted?
+            if SequenceServer.makeblastdb.any_to_format?
               formatted = SequenceServer.makeblastdb.format
               exit! if formatted.empty? && !set?
               redo unless set?
@@ -353,7 +353,7 @@ begin
       end
 
       if make_blast_databases?
-        if SequenceServer.makeblastdb.scan
+        if SequenceServer.makeblastdb.any_to_format_or_reformat?
           puts
           puts <<~MSG
           SequenceServer has scanned your databases directory and will now offer

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -62,6 +62,9 @@ module SequenceServer
 
     # SequenceServer initialisation routine.
     def init(config = {})
+      # Reset makeblastdb cache, because configuration may have changed.
+      @makeblastdb = nil
+
       # Use default config file if caller didn't specify one.
       config[:config_file] ||= DEFAULT_CONFIG_FILE
 
@@ -201,8 +204,7 @@ module SequenceServer
 
       logger.debug("Will look for BLAST+ databases in: #{config[:database_dir]}")
 
-      makeblastdb.scan
-      fail NO_BLAST_DATABASE_FOUND, config[:database_dir] if !makeblastdb.any_formatted?
+      fail NO_BLAST_DATABASE_FOUND, config[:database_dir] unless makeblastdb.any_formatted?
 
       Database.collection = makeblastdb.formatted_fastas
       Database.each do |database|

--- a/lib/sequenceserver/makeblastdb.rb
+++ b/lib/sequenceserver/makeblastdb.rb
@@ -8,7 +8,8 @@ module SequenceServer
   # Example usage:
   #
   #   makeblastdb = MAKEBLASTDB.new(database_dir)
-  #   makeblastdb.scan && makeblastdb.run
+  #   makeblastdb.run # formats and re-formats databases in database_dir
+  #   makeblastdb.formatted_fastas # lists formatted databases
   #
   class MAKEBLASTDB
     extend Forwardable
@@ -19,55 +20,18 @@ module SequenceServer
       @database_dir = database_dir
     end
 
-    attr_reader :database_dir, :formatted_fastas, :fastas_to_format, :fastas_to_reformat
+    attr_reader :database_dir
 
-    # Scans the database directory to determine which FASTA files require
-    # formatting or re-formatting.
-    #
-    # Returns `true` if there are files to (re-)format, `false` otherwise.
-    def scan
-      # We need to know the list of formatted FASTAs as reported by blastdbcmd
-      # first. This is required to determine both unformatted FASTAs and those
-      # that require reformatting.
-      @formatted_fastas = []
-      determine_formatted_fastas
-
-      # Now determine FASTA files that are unformatted or require reformatting.
-      @fastas_to_format = []
-      determine_unformatted_fastas
-      @fastas_to_reformat = []
-      determine_fastas_to_reformat
-
-      # Return true if there are files to be (re-)formatted or false otherwise.
-      !@fastas_to_format.empty? || !@fastas_to_reformat.empty?
-    end
-
-    # Returns true if at least one database in database directory is formatted.
     def any_formatted?
-      !@formatted_fastas.empty?
+      formatted_fastas.any?
     end
 
-    # Returns true if there is at least one unformatted FASTA in the databases
-    # directory.
-    def any_unformatted?
-      !@fastas_to_format.empty?
+    def any_to_format_or_reformat?
+      any_to_format? || any_to_reformat?
     end
 
-    # Returns true if the databases directory contains one or more incompatible
-    # databases.
-    #
-    # Note that it is okay to only use V4 databases or only V5 databases.
-    # Incompatibility arises when they are mixed.
-    def any_incompatible?
-      return false if @formatted_fastas.all? { |ff| ff.v4? || ff.alias? }
-      return false if @formatted_fastas.all? { |ff| ff.v5? || ff.alias? }
-
-      true
-    end
-
-    # Runs makeblastdb on each file in `@fastas_to_format` and
-    # `@fastas_to_reformat`. Will do nothing unless `#scan`
-    # has been run before.
+    # Runs makeblastdb on each file in `fastas_to_format` and
+    # `fastas_to_reformat`.
     def run
       format
       reformat
@@ -78,9 +42,9 @@ module SequenceServer
     def format
       # Make the intent clear as well as ensure the program won't crash if we
       # accidentally call format before calling scan.
-      return unless @fastas_to_format
+      return unless any_to_format?
 
-      @fastas_to_format.select do |path, title, type|
+      fastas_to_format.select do |path, title, type|
         make_blast_database('format', path, title, type)
       end
     end
@@ -90,18 +54,20 @@ module SequenceServer
     def reformat
       # Make the intent clear as well as ensure the program won't crash if
       # we accidentally call reformat before calling scan.
-      return unless @fastas_to_reformat
+      return unless any_to_reformat?
 
-      @fastas_to_reformat.select do |path, title, type, non_parse_seqids|
+      fastas_to_reformat.select do |path, title, type, non_parse_seqids|
         make_blast_database('reformat', path, title, type, non_parse_seqids)
       end
     end
 
-    private
-
     # Determines which FASTA files in the database directory are already
-    # formatted. Adds to @formatted_fastas.
-    def determine_formatted_fastas
+    # formatted.
+    def formatted_fastas
+      return @formatted_fastas if defined?(@formatted_fastas)
+
+      @formatted_fastas = []
+
       blastdbcmd.each_line do |line|
         path, *rest = line.chomp.split("\t")
         next if multipart_database_name?(path)
@@ -109,31 +75,54 @@ module SequenceServer
         rest << get_categories(path)
         @formatted_fastas << Database.new(path, *rest)
       end
+
+      @formatted_fastas
+    end
+
+    private
+
+    def any_to_format?
+      fastas_to_format.any?
+    end
+
+    def any_to_reformat?
+      fastas_to_reformat.any?
     end
 
     # Determines which FASTA files in the database directory require
-    # reformatting. Adds to @fastas_to_format.
-    def determine_fastas_to_reformat
-      @formatted_fastas.each do |ff|
+    # reformatting.
+    def fastas_to_reformat
+      return @fastas_to_reformat if defined?(@fastas_to_reformat)
+
+      @fastas_to_reformat = []
+      formatted_fastas.each do |ff|
         @fastas_to_reformat << [ff.path, ff.title, ff.type, ff.non_parse_seqids?] if ff.v4? || ff.non_parse_seqids?
       end
+
+      @fastas_to_reformat
     end
 
     # Determines which FASTA files in the database directory are
-    # unformatted. Adds to @fastas_to_format.
-    def determine_unformatted_fastas
+    # unformatted.
+    def fastas_to_format
+      return @fastas_to_format if defined?(@fastas_to_format)
+
+      @fastas_to_format = []
+
       # Add a trailing slash to database_dir - Find.find doesn't work as
       # expected without the trailing slash if database_dir is a symlink
       # inside a docker container.
       Find.find(database_dir + '/') do |path|
         next if File.directory?(path)
         next unless probably_fasta?(path)
-        next if @formatted_fastas.any? { |f| f[0] == path }
+        next if formatted_fastas.any? { |f| f[0] == path }
 
         @fastas_to_format << [path,
                               make_db_title(path),
                               guess_sequence_type_in_fasta(path)]
       end
+
+      @fastas_to_format
     end
 
     # Runs `blastdbcmd` to determine formatted FASTA files in the database


### PR DESCRIPTION
SequenceServer MAKEBLASTDB wrapper was working in two-steps: 

1) invoke #scan - this was eagerly scanning for formatted,
  unformatted and DBs that may require reformatting and storing
  them in instance variables
2) whenever any makeblast operation was performed, it relied on scan
  being run beforehand to populate the instance variables and was
  using these values to perform listing, formatting and reformatting
  operations.

When SequienceServer.init was invoked (any time the web server starts or the CLI binary is launched) it was calling makeblastdb.scan regardless of whether it will format/reformat the databases. This was rather slow on large database dirs (I saw upwards of a minute on a large dir).

This change refactors MAKEBLASTDB wrapper to only scan for DBs to format or reformat when it is actually going to perform any of these operations.

Now the class does not rely on running #scan beforehand to perform any operations, and invokes the data gathering methods lazilly (i.e. only when gathering data is required), making sure it does not perform any slow operations when they are not necessary.