### PR TITLE
[Performance] Add --optimistic flag that skips DB checks

### DIFF
--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -119,6 +119,11 @@ begin
        'Port to run SequenceServer on',
        argument: true
 
+    on 'o', 'optimistic=',
+       'Optimistic mode does not perform database compatibility checks, which can be faster. ' \
+       'Only use this if you format FASTAs with "sequenceserver -make-blast-databases"',
+       argument: true
+
     on 's', 'set',
        'Set configuration value in default or given config file'
 

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -207,6 +207,10 @@ module SequenceServer
       fail NO_BLAST_DATABASE_FOUND, config[:database_dir] unless makeblastdb.any_formatted?
 
       Database.collection = makeblastdb.formatted_fastas
+      check_database_compatibility unless config[:optimistic].to_s == 'true'
+    end
+
+    def check_database_compatibility
       Database.each do |database|
         logger.debug "Found #{database.type} database '#{database.title}' at '#{database.path}'"
         if database.non_parse_seqids?

--- a/lib/sequenceserver/config.rb
+++ b/lib/sequenceserver/config.rb
@@ -132,7 +132,9 @@ module SequenceServer
         job_lifetime: 43_200,
         # Set cloud_share_url to 'disabled' to disable the cloud sharing feature
         cloud_share_url: 'https://share.sequenceserver.com/api/v1/shared-job',
-        large_result_warning_threshold: 250 * 1024 * 1024
+        # Warn in the UI before rendering results larger than this value
+        large_result_warning_threshold: 250 * 1024 * 1024,
+        optimistic: false # Faster, but does not perform DB compatibility checks
       }
     end
   end

--- a/spec/sequenceserver_spec.rb
+++ b/spec/sequenceserver_spec.rb
@@ -86,5 +86,28 @@ module SequenceServer
       Database.all.should_not be_empty
       Database.all.length.should == 4
     end
+
+    describe '--optimistic' do
+      it 'scans for DB incompatibilities by default' do
+        allow(SequenceServer).to receive(:check_database_compatibility)
+
+        SequenceServer.init(
+          database_dir: File.join(__dir__, 'database', 'v5', 'sample')
+        )
+
+        expect(SequenceServer).to have_received(:check_database_compatibility).once
+      end
+
+      it 'scans does not scan for DB incompatibilities in optimistic mode' do
+        allow(SequenceServer).to receive(:check_database_compatibility)
+
+        SequenceServer.init(
+          database_dir: File.join(__dir__, 'database', 'v5', 'sample'),
+          optimistic: true
+        )
+
+        expect(SequenceServer).to_not have_received(:check_database_compatibility)
+      end
+    end
   end
 end


### PR DESCRIPTION
By default, when running SequenceServer.init i.e. when starting the web server or runninc CLI commands, it will scan the entire database_dir entries to find databases that use older (v4) version or have been created without parse_seqids. If this is the case it will log a warning.

If all databases are formatted correctly and the user knows it, running SequenceServer with --optimistic can have a significant impact on reducing startup times. With vast databse directories this can be in tens of seconds.

This is because parse_seqids in particular does a lot of IO calls to scan database directories to determine if seqids metadata files are missing for each database.

I think this also constitutes a 2.2.0 gem release