### PR TITLE
Log when makeblastdb is provided a dir without fastas

### DIFF
--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -358,7 +358,9 @@ begin
       end
 
       if make_blast_databases?
-        if SequenceServer.makeblastdb.any_to_format_or_reformat?
+        if SequenceServer.makeblastdb.no_fastas?
+          puts "Couldn't find any FASTA files in #{SequenceServer.config[:database_dir]}."
+        elsif SequenceServer.makeblastdb.any_to_format_or_reformat?
           puts
           puts <<~MSG
           SequenceServer has scanned your databases directory and will now offer
@@ -380,7 +382,7 @@ begin
           print '>> '
           response = STDIN.gets.to_s.strip
           SequenceServer.makeblastdb.run unless response =~ /^[n]$/i
-          else
+        else
           puts "All FASTA files in #{SequenceServer.config[:database_dir]} " \
                'are formatted.'
         end

--- a/spec/makeblastdb_spec.rb
+++ b/spec/makeblastdb_spec.rb
@@ -116,6 +116,21 @@ module SequenceServer
       expect(makeblastdb.send(:multipart_database_name?, sample_name3)).to be_truthy
     end
 
+    describe '#no_fastas?' do
+      it 'returns true if no FASTA files are found' do
+        makeblastdb = SequenceServer::MAKEBLASTDB.new(database_dir_without_parse_seqids)
+        expect(makeblastdb.no_fastas?).to be_truthy
+      end
+
+      it 'returns false if FASTA files are found' do
+        makeblastdb = SequenceServer::MAKEBLASTDB.new(database_dir_unformatted)
+        expect(makeblastdb.no_fastas?).to be_falsey
+
+        makeblastdb = SequenceServer::MAKEBLASTDB.new(database_dir_v4)
+        expect(makeblastdb.no_fastas?).to be_falsey
+      end
+    end
+
     describe '#make_blast_database' do
       context 'duplicate sequence ids' do
         before do


### PR DESCRIPTION
Previously, given a directory without any databases, the message would read 'All FASTAs are formatted', which could be misleading. 

Tell the user explicitly when SequenceServer cannot find any FASTAs. This is helpful for the user to know so that they can double-check the path provided, or check for non-standard file extensions in the dir.