### PR TITLE
Set encoding defaults to UTF-8

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -2,6 +2,9 @@ require 'English'
 require 'socket'
 require 'resolv'
 
+Encoding.default_external = 'UTF-8'
+Encoding.default_internal = 'UTF-8'
+
 # Top level module / namespace.
 module SequenceServer
   # The default version of BLAST that will be downloaded and configured for use.


### PR DESCRIPTION
If the underlying OS does not have `locale` configured, or has it configured to some other encoding, SequenceServer will pick it up and then fail given a UTF-8 string in a search field or other inputs.