### PR TITLE
Make response gzipping optional

### DIFF
--- a/lib/sequenceserver/routes.rb
+++ b/lib/sequenceserver/routes.rb
@@ -51,7 +51,9 @@ module SequenceServer
         frame_options = SequenceServer.config[:frame_options]
         frame_options && { frame_options: frame_options }
       }
+    end
 
+    unless ENV['SEQUENCE_SERVER_COMPRESS_RESPONSES'] == 'false'
       # Serve compressed responses.
       use Rack::Deflater
     end


### PR DESCRIPTION
Allow to disable response compression via an environment variable.