### PR TITLE
Render JSON error when it occurs on a request path ending with .json

### DIFF
--- a/lib/sequenceserver/routes.rb
+++ b/lib/sequenceserver/routes.rb
@@ -297,7 +297,7 @@ module SequenceServer
         error_data[:more_info] = error.backtrace.join("\n")
       end
 
-      if request.env['HTTP_ACCEPT'].to_s.include?('application/json')
+      if request.env['HTTP_ACCEPT'].to_s.include?('application/json') || request.path.end_with?('.json')
         status 422
         content_type :json
         error_data.to_json


### PR DESCRIPTION
While ACCEPT header might not be passed in these requests, paths ending with .json are likely to expect a JSON response, so when an error occurs, respond with a JSON error.

This fixes error modal in such requests and displays an informative message now instead of empty content.