### PR TITLE
Redudancy removal #485

### DIFF
--- a/lib/sequenceserver/sequence.rb
+++ b/lib/sequenceserver/sequence.rb
@@ -206,7 +206,7 @@ module SequenceServer
           # `split` to fail. We replace invalid UTF-8 characters with X.
           line = line.encode('UTF-8', invalid: :replace, replace: 'X')
           Sequence.new(*line.chomp.split('	'))
-        end
+        end.uniq
 
         @batch_file.unlink
         extend(IO) && write if in_file

--- a/lib/sequenceserver/sequence.rb
+++ b/lib/sequenceserver/sequence.rb
@@ -206,7 +206,7 @@ module SequenceServer
           # `split` to fail. We replace invalid UTF-8 characters with X.
           line = line.encode('UTF-8', invalid: :replace, replace: 'X')
           Sequence.new(*line.chomp.split('	'))
-        end.uniq
+        end
 
         @batch_file.unlink
         extend(IO) && write if in_file

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -78,6 +78,17 @@ module SequenceServer
     TSYCGP
     "
     end
+    let(:query_with_duplicate_sequence) do
+    'MSANRLNVLVTLMLAVALLVTESGNAQVDGYLQFNPKRSAVSSPQKYCGKKLSNALQIIC
+    DGVYNSMFKKSGQDFPPQNKRHIAHRINGNEEESFTTLKSNFLNWCVEVYHRHYRFVFVS
+    EMEMADYPLAYDISPYLPPFLSRARARGMLDGRFAGRRYRRESRGIHEECCINGCTINEL
+    TSYCGP
+    >SI2.2.0_13722 locus=Si_gnF.scaffold06207[1925625..1928536].pep_1 quality=100.00
+    MSANRLNVLVTLMLAVALLVTESGNAQVDGYLQFNPKRSAVSSPQKYCGKKLSNALQIIC
+    DGVYNSMFKKSGQDFPPQNKRHIAHRINGNEEESFTTLKSNFLNWCVEVYHRHYRFVFVS
+    EMEMADYPLAYDISPYLPPFLSRARARGMLDGRFAGRRYRRESRGIHEECCINGCTINEL
+    TSYCGP'
+    end
 
     # all databases used here are v5 databases included in
     # SequenceServer.init(database_dir: "#{__dir__}/database")
@@ -125,6 +136,11 @@ module SequenceServer
         databases: [Database.ids[17]],
         method: 'blastp'
       }
+      @params_query_with_duplicate_sequence = {
+        sequence: query_with_duplicate_sequence,
+        databases: [Database.ids[17]],
+        method: 'blastp'
+      }
       @params_query_with_and_without_symbol ={
         sequence: query_with_and_without_symbol,
         databases: [Database.ids[17]],
@@ -139,6 +155,12 @@ module SequenceServer
     end
     context 'queries containing a > at the start' do
         let(:job) {Job.create(@params_query_with_symbol)}
+      it 'should accurately compute number of sequences' do
+        expect(job.number_of_query_sequences).to eq(1)
+      end
+    end
+    context 'queries containing duplicate sequence' do
+        let(:job) {Job.create(@params_query_with_duplicate_sequence)}
       it 'should accurately compute number of sequences' do
         expect(job.number_of_query_sequences).to eq(1)
       end


### PR DESCRIPTION
I do test using sending 2 identiq query, it will give me redundant results, but when I do download it giving me this error message on fasta file

```
# ERROR: incorrect number of sequences found.
# You requested 14 sequence(s) with the following
# identifiers:
#   SI2.2.0_06267, ref|XM_039451179.1|, ref|XM_039451177.1|, ref|XM_039451188.1|, ref|XM_039451192.1|, ref|XM_011159896.3|, ref|XM_039451197.1|, SI2.2.0_06267, ref|XM_039451179.1|, ref|XM_039451177.1|, ref|XM_039451188.1|, ref|XM_039451192.1|, ref|XM_011159896.3|, ref|XM_039451197.1|
# from the following databases:
#   Hereis assembly one 2022-04 , sequenceserver-18 hits
# but we found 7 sequence(s).
# 
# This is likley due to a problem with how databases are formatted.
# Please share this text with the person managing this website.
# 
# If you are the admin and are confident that your databases are
# correctly formatted, you have likely encountered a weird bug.
# In this case, please raise an issue at:
# https://github.com/wurmlab/sequenceserver/issues
# 
# If any sequences were retrieved, you can find them below
# (but some may be incorrect, so be careful!)
```