### PR TITLE
Fix: bad unit labels

### DIFF
--- a/public/js/length_distribution.js
+++ b/public/js/length_distribution.js
@@ -105,7 +105,7 @@ class Graph {
                 if (suffixes[seq_type] == 'aa') {
                     return `${d} ${suffixes[seq_type]}`;
                 } else {
-                    return `${prefix(d)} ${suffixes[seq_type]}`;
+                    return `${prefix(d)}${suffixes[seq_type]}`.replace(/([a-zA-Z]+)/, ' $1');
                 }
             } else {
                 return ;

--- a/public/js/visualisation_helpers.js
+++ b/public/js/visualisation_helpers.js
@@ -43,7 +43,7 @@ export function tick_formatter(scale, seq_type) {
 
     return function (d) {
         return `${prefix(d)}${suffixes[seq_type]}`
-            .replace(/([0-9])([a-zA-Z])/g, '$1 $2');
+            .replace(/([a-zA-Z]+)/, ' $1')
     };
 }
 

--- a/public/js/visualisation_helpers.js
+++ b/public/js/visualisation_helpers.js
@@ -42,7 +42,8 @@ export function tick_formatter(scale, seq_type) {
     var suffixes = {amino_acid: 'aa', nucleic_acid: 'bp'};
 
     return function (d) {
-        return `${prefix(d)} ${suffixes[seq_type]}`;
+        return `${prefix(d)}${suffixes[seq_type]}`
+            .replace(/([0-9])([a-zA-Z])/g, '$1 $2');
     };
 }
 


### PR DESCRIPTION
Fix unit labels from

`1k bp` or `12M aa`

to 

`1 kbp` or `12 Maa`