### PR TITLE
chore: remove references to Google Group (#832)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM docker.io/ncbi/blast-static:${BLAST_VERSION} AS ncbi-blast
 FROM docker.io/library/ruby:3.2-bookworm AS final
 
 LABEL Description="Intuitive local web frontend for the BLAST bioinformatics tool"
-LABEL MailingList="https://groups.google.com/forum/#!forum/sequenceserver"
+LABEL MailingList="https://support.sequenceserver.com"
 LABEL Website="http://sequenceserver.com"
 
 # Install packages required to run SequenceServer and BLAST.

--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -326,13 +326,13 @@ begin
         # Ideally we will never hit this block. If we do, there's a bug in
         # SequenceServer or something really weird going on. If we hit this
         # error block we show the stacktrace to the user requesting them to
-        # post the same to our Google Group.
+        # post the same to our Community Support.
         puts <<~MSG
           Something went wonky
 
           Looks like you have encountered a bug in SequenceServer. Please could you
-          report this incident to our Google Group -
-          https://groups.google.com/forum/?fromgroups#!forum/sequenceserver
+          report this incident to our Community Support -
+          https://support.sequenceserver.com
 
           Error:
             #{e.backtrace.unshift(e.message).join("\n")}
@@ -373,7 +373,7 @@ begin
           fail if sequence identifiers are longer than 50 characters. While we
           exepect the reformatting process to work in most other cases, things
           can inevitably go wrong. Thus, please back up your databases before
-          reformatting and post any issues to our Google Group/GitHub so that
+          reformatting and post any issues to our Community Support/GitHub so that
           we can all learn from it.
 
           Proceed? [y/n] (Default: y).

--- a/lib/sequenceserver/api_errors.rb
+++ b/lib/sequenceserver/api_errors.rb
@@ -120,7 +120,7 @@ module SequenceServer
         databases, or advanced parameters. Details of the error are included
         below. Please ask on our
         <a href="https://github.com/wurmlab/sequenceserver/issues" target="_blank">issue tracker</a>
-        or on our <a href="https://groups.google.com/g/sequenceserver">forum</a> if you are
+        or on our <a href="https://support.sequenceserver.com">forum</a> if you are
         not sure what the error message means, or if the error message is just a number.
       MSG
     end

--- a/lib/sequenceserver/exceptions.rb
+++ b/lib/sequenceserver/exceptions.rb
@@ -143,7 +143,7 @@ module SequenceServer
         Error:
           #{out.strip}
 
-        Please could you report this to 'https://groups.google.com/forum/#!forum/sequenceserver'?
+        Please could you report this to 'https://support.sequenceserver.com'?
       MSG
     end
   end


### PR DESCRIPTION
This PR addresses issue #832 by removing all references to the Google Group and replacing them with links or mentions of Community Support.

Related Issue
Closes #832

Changes
Replaced Google Group references with Community Support