### PR TITLE
Flatten the links array

### DIFF
--- a/lib/sequenceserver/blast/hit.rb
+++ b/lib/sequenceserver/blast/hit.rb
@@ -38,8 +38,7 @@ module SequenceServer
       # instance methods of the Links module.
       def links
         links = Links.instance_methods.map { |m| send m }
-        links.compact!
-        links.sort_by { |link| [link[:order], link[:title]] }
+        links.flatten.compact.sort_by { |link| [link[:order], link[:title]] }
       end
 
       # Returns the database type (nucleotide or protein).


### PR DESCRIPTION
Allows each links.rb to return multiple links if needed.