### PR TITLE
Fix file extension to enable sequence retrieval for format 4 databases

### DIFF
--- a/lib/sequenceserver/database.rb
+++ b/lib/sequenceserver/database.rb
@@ -85,7 +85,7 @@ module SequenceServer
       when '5'
         (%w[nog nos pog pos] & extensions).length != 2
       when '4'
-        (%w[nog nsd nsi pod psd psi] & extensions).length != 3
+        (%w[nog nsd nsi pog psd psi] & extensions).length != 3
       end
     end
 


### PR DESCRIPTION
Hi,

Sequence retrieval is currently not possible for protein databases with format 4: "FASTA of all hits" or "FASTA of selected hit's)"  are not displayed in the left panel, whereas the databases have been generated with the --parse_seqids option.

I have this bug with the v2.1.0 release, but the wrong extension (.pod) appears in the code from the 2.0.0 release. Could you please update this in all impacted releases ?

Thanks a lot!